### PR TITLE
Fix Getting the Nodes Full Path

### DIFF
--- a/controls/treeview/application-scenarios/client-side-programming/getting-the-nodes-full-path.md
+++ b/controls/treeview/application-scenarios/client-side-programming/getting-the-nodes-full-path.md
@@ -22,6 +22,9 @@ var currentObject = node.get_parent();
 while (currentObject != null) {
     // get_parent() will return null when we reach the treeview
     if (currentObject.get_parent() != null) {
+    	
+    	if(!currentObject.get_text)
+                        break;
         s = currentObject.get_text() + " > " + s;
     }
     currentObject = currentObject.get_parent();


### PR DESCRIPTION
get_parent() function will not return null when you put treeview in another telerik control, like RadWizardStep.