### PR TITLE
Update custom-attributes.md

### DIFF
--- a/controls/combobox/radcombobox-items/custom-attributes.md
+++ b/controls/combobox/radcombobox-items/custom-attributes.md
@@ -33,8 +33,8 @@ To customize RadComboBox items, this example uses an item [template]({%slug comb
 				<img src='Images/<%# DataBinder.Eval(Container, "Attributes['ImagePath']") %>' alt="" />
 			</td>
 			<td>
-				<%# DataBinder.Eval(Container"Attributes['DisplayName']") %>
-				(<%# DataBinder.Eval(Container"Text") %>)
+				<%# DataBinder.Eval(Container, "Attributes['DisplayName']") %>
+				(<%# DataBinder.Eval(Container, "Text") %>)
 			</td>
 		</tr>
 	</table>


### PR DESCRIPTION
<%# DataBinder.Eval(Container"Attributes['DisplayName']") %>
                (<%# DataBinder.Eval(Container"Text") %>)

Commas were missing after "Container".

Telerik User Account: jon.shipman@perryhomes.com