### PR TITLE
Update group-title.md

### DIFF
--- a/controls/tilelist/functionality/group-title.md
+++ b/controls/tilelist/functionality/group-title.md
@@ -10,7 +10,7 @@ position: 4
 
 # Group Title
 
-**RadTileList** offers **group titles** (**Figure 1**) as of **Q1 2016**. To set the title of a group, use its `Title` property (**Example 1**). You can also set it on the client-side via the `set_groupTitle` method (**Example 2**).
+**RadTileList** offers **group titles** (**Figure 1**) as of **Q1 2016**. To set the title of a group, use its `Title` property (**Example 1**). You can also set it on the client side via the `set_groupTitle` method (**Example 2**).
 
 When data binding a TileList control, you can set the group titles declaratively when you [define the groups structure]({%slug tilelist/data-binding/defining-structure%}). Alternatively, you can use the [OnTileDataBound]({%slug tilelist/server-side-programming/server-side-events/ontiledatabound%}) event to access the associated data item and set a group's title according to your business logic. You can see this in action in the [Declarative DataSource](http://demos.telerik.com/aspnet-ajax/tilelist/examples/data-binding/server-side-binding/declarative-data-source/defaultcs.aspx) Live Demo.
 
@@ -37,7 +37,7 @@ When data binding a TileList control, you can set the group titles declaratively
 </telerik:RadTileList>
 ```` 
 
->caption Example 2: Set group title client-side.
+>caption Example 2: Set group title on the client side.
 
 ````ASP.NET
 <asp:Button ID="Button1" Text="set group titles" OnClientClick="setGroupTitles(); return false;" runat="server" />


### PR DESCRIPTION
Minor changes. Note that client side (or server side) is only hyphenated when you use it as an adjective. So look at these two examples:

Ex 1: Use this script to change the titles on the client side, or just manually change it.
Ex 2: You can use a client-side script to change the titles.

Feel free to pass that on to the team if you keep a document of things like this (when I worked there I had a list of terms - frankly you might just want to have one in GitHub for all of the teams to share so others can contribute to it).