### PR TITLE
Update image.md

### DIFF
--- a/controls/togglebutton/functionality/image.md
+++ b/controls/togglebutton/functionality/image.md
@@ -42,15 +42,15 @@ You can control the image dimensions through the **Width** and **Height** proper
 
 >note If you add toggle states with and witout images, the RadToggleButton control will no longer be considered a button but a custom image. Thus, the borders and default backgrounds of the non-image toggle state will be lost and the appearance of the control will change.
 
-## Hovered, Active and Disabled States
+## Hovered, Active (Pressed) and Disabled States
 
-**RadToggleButton** also provides an easy way to show different images when the mouse is hovered over the control, the button is pressed or the button is disabled (see **Figure 2** and **Example 2**). To do this, use the **PressedUrl**, **HoveredUrl**, **DisabledUrl** properties exposed by the **Image** tag of each toggle state.
+**RadToggleButton** also provides an easy way to show different images when the mouse is hovered over the control, the button is pressed or the button is disabled (see **Figure 2** and **Example 2**). To do this, use the **HoveredUrl**, **PressedUrl** and **DisabledUrl** properties exposed by the **Image** tag of each toggle state.
 
->caption Figure 2: A RadToggleButton can have different images for its normal, hovered, active and disabled state.
+>caption Figure 2: A RadToggleButton can have different images for its normal, hovered, active (pressed) and disabled state.
 
 ![RadToggleButton with image states](images/toggle-button-image-states.png)
 
->caption Example 2: Setup unique images for the normal, hovered, active and disabled state of a RadToggleButton.
+>caption Example 2: Setup unique images for the normal, hovered, active (pressed) and disabled state of a RadToggleButton.
 
 ````ASP.NET
 <telerik:RadToggleButton runat="server" ID="RadToggleButton1" Width="58px" Height="59px">

--- a/controls/togglebutton/functionality/image.md
+++ b/controls/togglebutton/functionality/image.md
@@ -10,11 +10,11 @@ position: 1
 
 # Image
 
-This help article illustrates how to put an **image** in a toggle state of **RadToggleButton**.
+This help article illustrates how to put an **image** in a toggle state on a **RadToggleButton**.
 
-To define an image in **RadToggleButton** you should set the path to the image inside the **Image.Url** property of each toggle state (**Example 1**). You can also show text over the image by simply setting it in the **Text** property.
+To define an image in a **RadToggleButton** you should set the path to the image inside the **Image.Url** property of each toggle state (**Example 1**). You can also show text over the image by simply setting it in the **Text** property.
 
-You can control the image dimensions through the **Width** and **Height** properties which are exposed globally (the **RadToggleButton** object) as well as per each toggle state (the **ButtonToggleState** objects).
+You can control the image dimensions through the **Width** and **Height** properties, which are exposed globally (the **RadToggleButton** object) as well as in each toggle state (the **ButtonToggleState** objects).
 
 >caption Figure 1: RadToggleButton with image.
 
@@ -44,7 +44,7 @@ You can control the image dimensions through the **Width** and **Height** proper
 
 ## Hovered, Active and Disabled States
 
-**RadToggleButton** also provides an easy way to show different images when the mouse is over the control, the button is pressed or disabled (see **Figure 2** and **Example 2**). To do this, use the **PressedUrl**, **HoveredUrl**, **DisabledUrl** properties exposed by the **Image** tag of each toggle state.
+**RadToggleButton** also provides an easy way to show different images when the mouse is hovered over the control, the button is pressed or the button is disabled (see **Figure 2** and **Example 2**). To do this, use the **PressedUrl**, **HoveredUrl**, **DisabledUrl** properties exposed by the **Image** tag of each toggle state.
 
 >caption Figure 2: A RadToggleButton can have different images for its normal, hovered, active and disabled state.
 


### PR DESCRIPTION
I made some minor edits that you will agree with, but I wonder if this headline "Hovered, Active and Disabled States" is a little misleading. The properties in the article are PressedUrl, HoveredUrl and DisabledUrl and I don't think "pressed" and "active" are the same thing. In example 2 you also discuss an image for the button in normal state. Why isn't "normal" part of the same headline? Is there also a property for normal that isn't discussed in the article?
Also, your slug for this article doesn't match the properties discussed in the article, so that's worse for search.