### PR TITLE
Update strip-html-on-paste.md

### DIFF
--- a/controls/editor/how-to/strip-html-on-paste.md
+++ b/controls/editor/how-to/strip-html-on-paste.md
@@ -12,14 +12,14 @@ position: 7
 
 This help article shows how to strip HTML tags from content that is pasted in **RadEditor**.
 
-In order to implement that you should:
+In order to implement this custom solution, you should:
 
-1. Handle the [OnClientPasteHtml event]({%slug editor/client-side-programming/events/onclientpastehtml%}); 
-2. Catch the **Paste** command.;
-2. Obtain the content via the `get_value()` method of the event arguments and modify it as needed;
+1. Handle the [OnClientPasteHtml event]({%slug editor/client-side-programming/events/onclientpastehtml%}). 
+2. Catch the **Paste** command.
+3. Obtain the content via the `get_value()` method of the event arguments and modify it as needed.
 4. Set the modified content via the `set_value()` method of the event arguments.
  
->caption Example 1: Basic example for strippping `<strong>`, `<em>` and `<span>` tags on paste in **RadEditor**.
+>caption Example 1: Stripping `<strong>`, `<em>` and `<span>` tags on paste in **RadEditor**.
 
 ````ASP.NET
 <telerik:RadEditor runat="server" ID="RadEditor1" OnClientPasteHtml="OnClientPasteHtml" />

--- a/controls/editor/how-to/strip-html-on-paste.md
+++ b/controls/editor/how-to/strip-html-on-paste.md
@@ -12,7 +12,7 @@ position: 7
 
 This help article shows how to strip HTML tags from content that is pasted in **RadEditor**.
 
-In order to implement this custom solution, you should:
+In order to implement this solution, you should:
 
 1. Handle the [OnClientPasteHtml event]({%slug editor/client-side-programming/events/onclientpastehtml%}). 
 2. Catch the **Paste** command.


### PR DESCRIPTION
The punctuation at the end of lists should generally be a period, not a semi-colon.
I think the markdown for a numbered list is to begin each line with a 1. but you specifically numbered them at 1. 2. 3. 4.  I left it but decided to leave you this comment to check the syntax.
The description of the article says that the article teaches how to strip "some" HTML but the actual body of the article does not suggest that there are limitations. Can this technique strip some kinds of HTML but not others? Perhaps add a note about that?