### PR TITLE
Update week-view.md

### DIFF
--- a/controls/gantt/views/week-view.md
+++ b/controls/gantt/views/week-view.md
@@ -31,8 +31,6 @@ The **Week View** shows all loaded tasks for a **RadGantt** distributed in colum
 | **UserSelectable** |bool|Gets or sets a value indicating whether to render a tab for the **WeekView** in the view chooser.|
 | **WeekHeaderDateFormat** |string|Gets or sets the week header date format string in **WeekView**.|
 
-<Comment: Why does the DateTime type have a question mark?>
-
 # See Also
 
  * [Views Overview]({%slug gantt/views/overview%})
@@ -44,5 +42,4 @@ The **Week View** shows all loaded tasks for a **RadGantt** distributed in colum
  * [Year View]({%slug gantt/views/year-view%})
  
  * [View types demo](http://demos.telerik.com/aspnet-ajax/gantt/examples/functionality/view-types/defaultcs.aspx)
-
 

--- a/controls/gantt/views/week-view.md
+++ b/controls/gantt/views/week-view.md
@@ -23,9 +23,9 @@ The **Week View** shows all loaded tasks for a **RadGantt** distributed in colum
 | Name | Type | Description |
 | ------ | ------ | ------ |
 | **DayHeaderDateFormat** |string|Gets or sets the day header date format string in **WeekView**.|
-| **RangeEnd** |DateTime?|Gets or sets the end time of the visible range of the **WeekView**. The **RangeEnd** date will not be included within the visible range.|
-| **RangeStart** |DateTime?|Gets or sets the start time of the visible range of the **WeekView**.|
-| **SelectedDate** |DateTime?|Gets or sets the date to which the timeline of the **WeekView** is scrolled.|
+| **RangeEnd** |DateTime?|Gets or sets the end date and time of the visible range of the **WeekView**. The **RangeEnd** date will not be included within the visible range.|
+| **RangeStart** |DateTime?|Gets or sets the start date and time of the visible range of the **WeekView**.|
+| **SelectedDate** |DateTime?|Gets or sets the date and time to which the timeline of the **WeekView** is scrolled.|
 | **SlotWidth** |Unit|Gets or sets the slot width in pixels for the **WeekView**.|
 | **Type** |Telerik.Web.UI.GanttViewType enumeration|Gets the type of the **View**. In this case a **WeekView**.|
 | **UserSelectable** |bool|Gets or sets a value indicating whether to render a tab for the **WeekView** in the view chooser.|

--- a/controls/gantt/views/week-view.md
+++ b/controls/gantt/views/week-view.md
@@ -1,36 +1,37 @@
 ---
-title: Weeek View
-page_title: Weeek View | RadGantt for ASP.NET AJAX Documentation
-description: Weeek View
+title: Week View
+page_title: Week View | RadGantt for ASP.NET AJAX Documentation
+description: Week View
 slug: gantt/views/week-view
 tags: week,view
 published: True
 position: 2
 ---
 
-# Weeek View
+# Week View
 
 
 
-The **Weeek View** shows all loaded tasks for a RadGantt, distributed in columns that have duration of one day. Those columns are further grouped in weeks. 
+The **Week View** shows all loaded tasks for a **RadGantt** distributed in columns that have duration of one day. Those columns are further grouped into weeks. 
 
 ![RadGantt in Week View](images/gantt-views-weekview.png)
 
-## Weeek View Settings:
+## WeekViewSettings Object
 
-**Table 1** demonstrates the properties, that are available within the **WeeekViewSettings** object.
+**Table 1** demonstrates the properties that are available within the **WeekViewSettings** object.
 
 | Name | Type | Description |
 | ------ | ------ | ------ |
 | **DayHeaderDateFormat** |string|Gets or sets the day header date format string in **WeekView**.|
-| **RangeEnd** |DateTime?|Gets or sets the end time of the visible range on the **WeekView**. The **RangeEnd** date will not be included within the visible range.|
-| **RangeStart** |DateTime?|Gets or sets the start time of the visible range on the **WeekView**.|
+| **RangeEnd** |DateTime?|Gets or sets the end time of the visible range of the **WeekView**. The **RangeEnd** date will not be included within the visible range.|
+| **RangeStart** |DateTime?|Gets or sets the start time of the visible range of the **WeekView**.|
 | **SelectedDate** |DateTime?|Gets or sets the date to which the timeline of the **WeekView** is scrolled.|
 | **SlotWidth** |Unit|Gets or sets the slot width in pixels for the **WeekView**.|
 | **Type** |Telerik.Web.UI.GanttViewType enumeration|Gets the type of the **View**. In this case a **WeekView**.|
 | **UserSelectable** |bool|Gets or sets a value indicating whether to render a tab for the **WeekView** in the view chooser.|
 | **WeekHeaderDateFormat** |string|Gets or sets the week header date format string in **WeekView**.|
 
+<Comment: Why does the DateTime type have a question mark?>
 
 # See Also
 


### PR DESCRIPTION
Minor copy edits. Many cases of Week spelled as Weeek were fixed. Check links from other help articles to this one if they relied on spelling.