### PR TITLE
Update strip-pasting-tools.md

### DIFF
--- a/controls/editor/functionality/toolbars/dropdowns/strip-pasting-tools.md
+++ b/controls/editor/functionality/toolbars/dropdowns/strip-pasting-tools.md
@@ -14,31 +14,31 @@ This article provides information about the built-in **Paste Strip** dropdown, a
 
 * [Overview](#overview)
 
-* [Adding Paste Strip Tool to a Custom Tool-set](#adding-paste-strip-tool-to-a-custom-tool-set)
+* [Adding the Paste Strip Tool to a Custom Toolset](#adding-paste-strip-tool-to-a-custom-tool-set)
 
 ## Overview
 
-The **Paste Strip** tools enable the end-user to strip the pasting of the content in the editor. The built-in **Paste Strip** dropdown exposes a list of **Paste Strip** tools for the user to choose from (**Figure 1**). The following list specifies each tool’s purpose:
+The **Paste Strip** tools enable the end user to strip the pasting of the content in the editor. The built-in **Paste Strip** dropdown exposes a list of **Paste Strip** tools for the user to choose from (**Figure 1**). The following list specifies each tool’s purpose:
 
-* **Paste**—performs a clipboard paste operation.
+* **Paste**: Performs a clipboard paste operation.
 
-* **[Paste from Word]({%slug editor/managing-content/pasting-content/clean-ms-word-formatting-%})**—pastes the content and strips unnecessary XML, HTML and comment element.
+* **[Paste from Word]({%slug editor/managing-content/pasting-content/clean-ms-word-formatting-%})**: Pastes the content and strips unnecessary XML, HTML and comment elements.
 
-* **Paste from Word, strip font**—performs the same operation as Paste from Word tool and additionally removes any font-related formatting (e.g., font size, color, etc.).
+* **Paste from Word, strip font**: Performs the same operation as Paste from Word tool and additionally removes any font-related formatting (e.g., font size, color, etc.).
 
-* **Paste Plain Text**—pastes the copied data as plain text, HTML tags are stripped down, and all styles are removed.
+* **Paste Plain Text**: Pastes the copied data as plain text, HTML tags are stripped down, and all styles are removed.
 
-* **Paste as Html**—pastes the copied content as HTML markup.
+* **Paste as Html*: Pastes the copied content as HTML markup.
 
-* **Paste Html**—enables the user to either type or paste HTML markup and insert it into the content. This tool opens a dialog for the content to be pasted.
+* **Paste Html**: Enables the user to either type or paste HTML markup and insert it into the content. This tool opens a dialog for the content to be pasted.
 
->caption Figure 1: Paste from word via the Paste Strip tool.
+>caption Figure 1: Paste from Word via the Paste Strip tool.
 
 ![editor-paste-strip](images/editor-paste-strip.png)
 
-## Adding Paste Strip Tool to a Custom Tool-set
+## Adding Paste Strip Tool to a Custom Toolset
 
-In a custom collection of tools, the build-in **Paste Strip** dropdown can be added by [adding a plain tool]({%slug editor/functionality/toolbars/overview%}) with a name set to	**PasteStrip** (**Example 1**).
+In a custom collection of tools, the build-in **Paste Strip** dropdown can be added by [adding a plain tool]({%slug editor/functionality/toolbars/overview%}) with a name set to **PasteStrip** (**Example 1**).
 
 >caption Example 1: Adding the PasteStrip dropdown to a tools collection.
 
@@ -64,13 +64,13 @@ In a custom collection of tools, the build-in **Paste Strip** dropdown can be ad
 </root>
 ````
 
-Optionally, you can further enable stand-alone **PasteStrip** tools in a toolbar or fine tune the collection inside the **PasteStrip** dropdown (**Example 2**).
+Optionally, you can further enable stand-alone **Paste Strip** tools in a toolbar or fine tune the collection inside the **Paste Strip** dropdown (**Example 2**).
 
 >caption Figure 2: The result of the tools collection configuration in Example 2.
 
 ![custom-paste-strip-tools-collection](images/custom-paste-strip-tools-collection.png)
 
->caption Example 2: Defining stand-alone PasteStrip tools in a toolbar and a custom set of tools in the PasteStrip dropdown.
+>caption Example 2: Defining stand-alone Paste Strip tools in a toolbar and a custom set of tools in the PasteStrip dropdown.
 
 ````ASP.NET
 //Defining PasteStrip with Tools collection:


### PR DESCRIPTION
Fixed formatting of the term lists. In most cases Paste Strip tools is, I think, the way to capitalize the term. However, when referring to the name of the menu in the caption for Figure 2, I wasn't sure if it should be two words or it should match the code in Example 2. Please check that.