### PR TITLE
copy edits only, no comments to review

### DIFF
--- a/controls/formdecorator/troubleshooting/decorated-gridview-is-not-bound-to-sqldatasource-with-controlparameter .md
+++ b/controls/formdecorator/troubleshooting/decorated-gridview-is-not-bound-to-sqldatasource-with-controlparameter .md
@@ -10,13 +10,13 @@ position: 2
 
 # Decorated GridView Is Not Bound to SqlDataSource with ControlParameter 
 
-This help article offers a solution to an issue where a decorated asp:GridView by RadFormDecorator cannot be bound to an SqlDataSource with ControlParameter on initial page load.
+This help article offers a solution to an issue where a decorated asp:GridView by RadFormDecorator cannot be bound to the SqlDataSource with a ControlParameter on initial page load.
 
 **Problem:**
 
-The asp:GridView cannot be bound on initial page load when it is decorated by RadFormDecorator and the GridView is bound to an SqlDataSource with ControlParameter. The issue can be reproduced with **Example 1**.
+The asp:GridView cannot be bound on initial page load when it is decorated by RadFormDecorator and the GridView is bound to the SqlDataSource with a ControlParameter. **Example 1** shows how to reproduce the issue.
 
->caption **Example 1**: Decorated asp:GridView is not visible on initial page load when it is bound to an SqlDataSource with ControlParameter.
+>caption **Example 1**: Decorated asp:GridView is not visible on initial page load when it is bound to the SqlDataSource with ControlParameter.
 
 **ASP.NET**
 
@@ -44,11 +44,11 @@ The asp:GridView cannot be bound on initial page load when it is decorated by Ra
 
 **Cause:**
 
-In order to decorate all the controls on the page, the RadFormDecorator decorates the children controls of the complex controls as well (i.e., the RadFormDecorator iterates through the controls' collections). 
+In order to decorate all of the controls on the page, the RadFormDecorator decorates the children controls of the complex controls as well (i.e., the RadFormDecorator iterates through the controls' collections). 
 
-There is, however, a binding issue with the GridView when an SqlDataSource is used with ControlParameter and at the same time the GridView's collection is accessed from the code behind. This issue can be easily reproduced on a page with no Telerik UI for ASP.NET AJAX controls and is shown in **Example 2**. The problem also affect the scenario with RadFormDecorator from **Example 1**.
+There is, however, a binding issue with the GridView when the SqlDataSource is used with a ControlParameter and at the same time, the GridView's collection is accessed from the code behind. This issue can be easily reproduced on a page with no Telerik UI for ASP.NET AJAX controls and is shown in **Example 2**. The problem also affects the scenario with the RadFormDecorator from **Example 1**.
 
->caption **Example 2**: asp:GridView cannot be bound to an SqlDataSource with ControlParameter when the GridView's collection is accessed from the code behind.
+>caption **Example 2**: asp:GridView cannot be bound to the SqlDataSource with a ControlParameter when the GridView's collection is accessed from the code behind.
 
 **ASP.NET**
 
@@ -87,7 +87,7 @@ There is, however, a binding issue with the GridView when an SqlDataSource is us
 
 **Solution:**
 
-There are a few options you can choose from, in order to handle the scenario described above.
+There are a few options you can choose from in order to handle the scenario described above.
 
 * Bind the DropDownList's data from the code behind instead of declaring the DataSourceID property of the DropDownList.
 
@@ -141,13 +141,13 @@ There are a few options you can choose from, in order to handle the scenario des
 
 * Skip the following controls form decoration - GridFormDetailsViews, LoginControls, Textbox and ValidationSummary:
 
-	>caption **Example 4**: Skip the GridFormDetailsViews,LoginControls,Textbox and ValidationSummary controls from decoration.
+	>caption **Example 4**: Skip the GridFormDetailsViews, LoginControls, Textbox and ValidationSummary controls from decoration.
 
 	**ASP.NET**
 
 		<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" ControlsToSkip="GridFormDetailsViews,LoginControls,Textbox,ValidationSummary" />
 
-* Set the DataSourceID property of the DropDownList in the Page_Init event. This approach, however, will force the dropdownlist to rebind itself which may lead to performance issues for large data sources.
+* Set the DataSourceID property of the DropDownList in the Page_Init event. This approach, however, will force the DropDownList to rebind itself, which may lead to performance issues for large data sources.
 
 	**C#**
 


### PR DESCRIPTION
I changed your use of "an SqlDataSource" to "the SqlDataSource" everywhere in the article. The problem here is that in English, you use the article "an" if the word that follows starts with a vowel sound, in this case you might think the reader pronounces "es-q-l-DataSource" but many people would also favor "a SqlDataSource" pronounced as "sequel-DataSource". This is tricky because you cannot correctly guess which way the reader would pronounce this in conversation. The solution is to reword as "the SqlDataSource" in all cases so you aren't trying to guess how the reader might pronounce the sound. I searched MSDN to see how Microsoft editors handle it and that is their solution. (Here is the search string: https://social.msdn.microsoft.com/Search/en-US?query=SqlDataSource&pgArea=header&emptyWatermark=true&ac=2)