### PR TITLE
fixed browser extension for api

### DIFF
--- a/web.config
+++ b/web.config
@@ -239,14 +239,6 @@
                         </rule>
                         {% endfor %}
                 {% endfor %}
-
-	    	<rule name="redirect-telerik-web-browser-client-api" enabled="true" stopProcessing="true">
-                    <match url="^api/client/Telerik.Web.Browser$" />
-                    <action type="Redirect" url="https://docs.telerik.com/devtools/aspnet-ajax/api/client/Telerik.Web.Browser.html" />
-                </rule>
-	    	<rule name="redirect-telerik-web-browser-client-api-html" enabled="true" stopProcessing="true">
-                    <match url="^api/client/Telerik.Web.Browser.html$" ignoreCase="true"  />
-                </rule>
                 <rule name="Redirecting .html ext" enabled="true">
                   <match url="^(.*)[.]html$"/>
                   <conditions logicalGrouping="MatchAny">
@@ -282,5 +274,15 @@
             <error statusCode="404" path="40x.html" />
        </httpErrors>
     </system.webServer>
-
+    <location path="api">
+        <system.webServer>
+            <security>
+             <requestFiltering>
+                <fileExtensions>
+                   <remove fileExtension=".browser" />
+                </fileExtensions>
+             </requestFiltering>
+            </security>
+        </system.webServer>
+    </location>
 </configuration>


### PR DESCRIPTION
This url (https://docs.telerik.com/devtools/aspnet-ajax/api/client/Telerik.Web.Browser) should now open.