### PR TITLE
Fix nuget package name in MCP server documentation

### DIFF
--- a/ai/mcp-server.md
+++ b/ai/mcp-server.md
@@ -32,7 +32,7 @@ The generic settings of the Telerik ASP.NET AJAX MCP server are:
 
 * Server name: `telerik-ajax-assistant`  (depends on your preferences)
 * Type: `stdio` (standard input/output transport)
-* Command: `dnx` (the MCP server works through a nuget package https://www.nuget.org/packages/Telerik.AspNetMvc.MCP)
+* Command: `dnx` (the MCP server works through a nuget package https://www.nuget.org/packages/Telerik.Ajax.MCP)
 * Supported arguments: `--yes`
 * nuget package name: `Telerik.Ajax.MCP`
 * You also need to add your [Telerik licence key](https://www.telerik.com/account/your-licenses/license-keys). Place the file at `%AppData%/Telerik/telerik-license.txt`; 


### PR DESCRIPTION
This pull request updates the documentation for the Telerik ASP.NET AJAX MCP server to correct the NuGet package name and its reference link.

Documentation update:

* Updated the NuGet package name and URL in the `ai/mcp-server.md` file from `Telerik.AspNetMvc.MCP` to `Telerik.Ajax.MCP` to ensure users reference the correct package.