### PR TITLE
Clarify AJAX accessibility and editor dropdown docs DTC-157

### DIFF
--- a/controls/editor/functionality/toolbars/dropdowns/custom-dropdown.md
+++ b/controls/editor/functionality/toolbars/dropdowns/custom-dropdown.md
@@ -37,6 +37,14 @@ Follow the steps below to create custom dropdown in-line in the editor's declara
 
 	To populate the items of the dropdown use the telerik:EditorDropDownItem inner tag of telerik:EditorDropDown. The **Name** attribute of the telerik:EditorDropDownItem tag represents the item name that will be rendered in the dropdown and the **Value** represents the value of the selected item.
 
+	The **ImageUrl** property of **EditorDropDown** sets the small toolbar icon when the editor uses RibbonBar mode. Set it to a URL or path that resolves to an image in the application, for example `ImageUrl="~/images/emoticons.png"`. It does not set an image for an individual dropdown item.
+
+	To display an image for an **EditorDropDownItem**, include an HTML `img` element in its **Name** attribute. The `src` can be an application-relative, relative, or absolute URL, and the **Value** can contain the image URL that your client-side command handler inserts into the editor. For example:
+
+	**ASP.NET**
+
+		<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil1.gif' alt='Smile' />" Value="./Emoticons/smil1.gif" />
+
 1. To create and configure a custom dropdown dynamically on the server use the code below:
 
 	**C#**

--- a/controls/radiobuttonlist/accessibility-and-internationalization/wai-aria-support.md
+++ b/controls/radiobuttonlist/accessibility-and-internationalization/wai-aria-support.md
@@ -20,12 +20,19 @@ In order to enable the WAI-ARIA support, set the **RadRadioButtonList** control'
 
 ````ASP.NET
 <telerik:RadRadioButtonList runat="server" ID="RadRadioButtonList1" EnableAriaSupport="true">
+    <AriaSettings DescribedBy="radioButtonListDescription" Label="Preferred language" />
     <Items>
         <telerik:RadioButtonListItem Text="English" Selected="true" />
         <telerik:RadioButtonListItem Text="German" />
         <telerik:RadioButtonListItem Text="French" />
     </Items>
 </telerik:RadRadioButtonList>
+````
+
+The `Label` value is used for the `aria-label` attribute. The `DescribedBy` value must be the `id` of an element that contains additional descriptive text, such as the following:
+
+````ASP.NET
+<asp:Label ID="radioButtonListDescription" runat="server" Text="Select the language for the application." />
 ````
 
 >note The implementation of the WAI-ARIA support is achieved entirely on the client side (using JavaScript) by appending different attributes and appropriate WAI-ARIA roles to the DOM elements. This is done because an HTML document containing ARIA attributes will not pass validation if they are added on the server.


### PR DESCRIPTION
Improves ASP.NET AJAX documentation based on SupportHeroes feedback:

- Adds concrete `AriaSettings` examples for RadioButtonList WAI-ARIA support.
- Clarifies `EditorDropDown.ImageUrl` and documents image syntax for dropdown items.