### PR TITLE
docs: repair code snippet formatting

### DIFF
--- a/controls/asyncupload/migrating-from-radupload-for-asp.net-ajax-to-radasyncupload.md
+++ b/controls/asyncupload/migrating-from-radupload-for-asp.net-ajax-to-radasyncupload.md
@@ -21,15 +21,15 @@ To migrate a web application from **RadUpload for ASP.NET AJAX** to the new **Ra
 
 1. Replace the old declaration:
 
-	**ASP.NET**
-	
-		<telerik:RadUpload …></telerik:RadUpload> 
+	```ASP.NET
+	<telerik:RadUpload …></telerik:RadUpload> 
+	```
 	
 	with the new one:
 
-	**ASP.NET**
-	
-		<telerik:RadAsyncUpload RenderMode="Lightweight" …></telerik:RadAsyncUpload> 
+	```ASP.NET
+	<telerik:RadAsyncUpload RenderMode="Lightweight" …></telerik:RadAsyncUpload> 
+	```
 
 
 1. You can leave all old properties intact.

--- a/controls/breadcrumb/client-side-programming/overview.md
+++ b/controls/breadcrumb/client-side-programming/overview.md
@@ -22,17 +22,17 @@ RadBreadcrumb is a server-side wrapper over the Kendo UI Breadcrumb Widget. Thus
 
 * Use the `get_kendoWidget()` method of the MS AJAX wrapper:
 
-    **JavaScript**
-
-        var breadcrumbObject  = $find("<%=RadBreadcrumb1.ClientID %>"); //the standard script control object
-        var kendoBreadcrumb = breadcrumbObject.get_kendoWidget(); //the Kendo widget
+    ```JavaScript
+    var breadcrumbObject  = $find("<%=RadBreadcrumb1.ClientID %>"); //the standard script control object
+    var kendoBreadcrumb = breadcrumbObject.get_kendoWidget(); //the Kendo widget
+    ```
 
 
 * Get the Kendo Widget in its usual way. Make sure to use the `$telerik._kendo.jQuery` reference that has the Kendo widget data:
 
-    **JavaScript**
-    
-        var kendoBreadcrumb = $telerik._kendo.jQuery("#<%=RadBreadcrumb1.ClientID %>").data("kendoBreadcrumb");
+    ```JavaScript
+    var kendoBreadcrumb = $telerik._kendo.jQuery("#<%=RadBreadcrumb1.ClientID %>").data("kendoBreadcrumb");
+    ```
 
 >important As of the 2026 Q1 release, Kendo jQuery widget plugins and data are registered on `$telerik._kendo.jQuery` — a different jQuery instance from `$telerik.$`. If you use `$telerik.$` with `.data("kendoXxx")`, it will return `undefined`. Always use `$telerik._kendo.jQuery` when accessing the underlying Kendo widget via the `.data()` method. The recommended approach, however, is to use the `get_kendoWidget()` method shown above. 
 

--- a/controls/button/appearance-and-styling/creating-a-custom-skin.md
+++ b/controls/button/appearance-and-styling/creating-a-custom-skin.md
@@ -34,10 +34,10 @@ Each of the controls included in the Telerik® UI for ASP.NET AJAX suite is styl
 
 7. Add a new server declaration of RadButton on your page, and set **Skin="MyCustomSkin"** and **EnableEmbeddedSkins=”false”**:
 
-	**ASP.NET**
-     
-		<telerik:RadButton RenderMode="Lightweight" ID="RadButton1" runat="server" Text="RadButton Submit" EnableEmbeddedSkins="false" Skin="MyCustomSkin">
-		</telerik:RadButton>		
+	```ASP.NET
+	<telerik:RadButton RenderMode="Lightweight" ID="RadButton1" runat="server" Text="RadButton Submit" EnableEmbeddedSkins="false" Skin="MyCustomSkin">
+	</telerik:RadButton>
+	```
 
 8. Register Button.MyCustomSkin.css in the ... section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 

--- a/controls/button/button-types/icons/overview.md
+++ b/controls/button/button-types/icons/overview.md
@@ -100,37 +100,37 @@ Alternatively, a CSS class can be set to the icon, and the position configured u
 
 1. Properties:
 
-	**ASP.NET**
-	
-		<telerik:RadButton RenderMode="Lightweight" ID="RadButton2" runat="server" Text="Spell Check Html">
-			<Icon PrimaryIconUrl="https://demos.telerik.com/aspnet-ajax/button/examples/customicons/images/eSpellCheck.png" 
-				PrimaryIconTop="4px" PrimaryIconLeft="5px"
-				SecondaryIconUrl="https://demos.telerik.com/aspnet-ajax/button/examples/customicons/images/eHtml.png" 
-				SecondaryIconTop="4px" SecondaryIconRight="5px" />
-		</telerik:RadButton>
+	```ASP.NET
+	<telerik:RadButton RenderMode="Lightweight" ID="RadButton2" runat="server" Text="Spell Check Html">
+		<Icon PrimaryIconUrl="https://demos.telerik.com/aspnet-ajax/button/examples/customicons/images/eSpellCheck.png" 
+			PrimaryIconTop="4px" PrimaryIconLeft="5px"
+			SecondaryIconUrl="https://demos.telerik.com/aspnet-ajax/button/examples/customicons/images/eHtml.png" 
+			SecondaryIconTop="4px" SecondaryIconRight="5px" />
+	</telerik:RadButton>
+	```
 
 1. Or the same configuration using CSS classes:
 
-	**CSS**
-	
-		<style type="text/css">
-			.classSpellCheck {
-				top: 4px;
-				left: 5px;
-			}
+	```CSS
+	<style type="text/css">
+		.classSpellCheck {
+			top: 4px;
+			left: 5px;
+		}
 
 			.classHtml {
 				top: 4px;
 				right: 5px;
 			}
-		</style>
+	</style>
+	```
 
-	**ASP.NET**
-
-		<telerik:RadButton RenderMode="Lightweight" ID="RadButton3" runat="server" Text="Spell Check Html">
-			<Icon PrimaryIconUrl="https://demos.telerik.com/aspnet-ajax/button/examples/customicons/images/eSpellCheck.png" PrimaryIconCssClass="classSpellCheck"
-				SecondaryIconUrl="https://demos.telerik.com/aspnet-ajax/button/examples/customicons/images/eHtml.png" SecondaryIconCssClass="classHtml" />
-		</telerik:RadButton>
+	```ASP.NET
+	<telerik:RadButton RenderMode="Lightweight" ID="RadButton3" runat="server" Text="Spell Check Html">
+		<Icon PrimaryIconUrl="https://demos.telerik.com/aspnet-ajax/button/examples/customicons/images/eSpellCheck.png" PrimaryIconCssClass="classSpellCheck"
+			SecondaryIconUrl="https://demos.telerik.com/aspnet-ajax/button/examples/customicons/images/eHtml.png" SecondaryIconCssClass="classHtml" />
+	</telerik:RadButton>
+	```
 	
 	
 	>caption Figure 3: Primary and Secondary icons in RadButton can be offset.

--- a/controls/button/getting-started.md
+++ b/controls/button/getting-started.md
@@ -14,25 +14,25 @@ The following tutorial demonstrates how to set up a page with a **RadButton** co
 
 1. In the default page of a new ASP.NET AJAX-enabled Web Application add a **RadButton** control:
 
-	**ASP.NET**	
-	
-		<telerik:RadButton RenderMode="Lightweight" id="RadButton1" runat="server" text="My Button">
-		</telerik:RadButton>	
+	```ASP.NET
+	<telerik:RadButton RenderMode="Lightweight" id="RadButton1" runat="server" text="My Button">
+	</telerik:RadButton>
+	```
 
 	The **Text** property specifies the text displayed in the **RadButton** control.
 
 1. To hook to the **OnClick** server-side event of **RadButton** switch to Design view of Visual Studio and double click on the button. This operation will insert the following function in the code behind file:
 
-	**C#**
-	
-		protected void RadButton1_Click(object sender, EventArgs e)
-		{
-		}
+	```C#
+	protected void RadButton1_Click(object sender, EventArgs e)
+	{
+	}
+	```
 
-	**VB**
-	
-		Protected Sub RadButton1_Click(ByVal sender As Object, ByVal e As EventArgs)
-		End Sub
+	```VB
+	Protected Sub RadButton1_Click(ByVal sender As Object, ByVal e As EventArgs)
+	End Sub
+	```
 
 	as well as add `OnClick="RadButton1_Click"` to the **RadButton**'s declaration.In the Click event handler add the code that you want to be executed when the **RadButton** control is clicked.
 

--- a/controls/captcha/functionality/caching-provider.md
+++ b/controls/captcha/functionality/caching-provider.md
@@ -18,11 +18,11 @@ The following example demonstrates how to utilize a MS SQL database for this pur
 
 1. The custom caching provider is registered in the **web.config** of the web site by setting the fully qualified name of the storage type to the following key. If the captcha is used in a web application scenario, the namespace of the application may need to be included in the fully qualified name:
 
-	**XML**
-
-		<appSettings>
-		  <add key="Telerik.Web.CaptchaImageStorageProviderTypeName" value="DBImageStorageProvider, App_Code.lfcwuanr, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"/>
-		</appSettings>
+	```XML
+	<appSettings>
+	  <add key="Telerik.Web.CaptchaImageStorageProviderTypeName" value="DBImageStorageProvider, App_Code.lfcwuanr, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+	</appSettings>
+	```
 
 1. Finally, the property **ImageStorageLocation** of RadCaptcha is set to **Custom**:
 

--- a/controls/captcha/getting-started.md
+++ b/controls/captcha/getting-started.md
@@ -24,40 +24,40 @@ The following tutorial demonstrates using **RadCaptcha** to validate page submis
 
 	>caption web.config
 	
-	**XML**
-	
-		<configuration>
-			<system.web>
-				<httpHandlers>
-					<add path="Telerik.Web.UI.WebResource.axd" type="Telerik.Web.UI.WebResource" verb="*" validate="false" /> 
-				</httpHandlers>
-			</system.web>
-			<system.webServer>
-				<handlers>
-					<add name="Telerik_Web_UI_WebResource_axd" verb="*" preCondition="integratedMode" path="Telerik.Web.UI.WebResource.axd" type="Telerik.Web.UI.WebResource" /> 
-				</handlers>
-			</system.webServer>
-		</configuration>
+	```XML
+	<configuration>
+		<system.web>
+			<httpHandlers>
+				<add path="Telerik.Web.UI.WebResource.axd" type="Telerik.Web.UI.WebResource" verb="*" validate="false" /> 
+			</httpHandlers>
+		</system.web>
+		<system.webServer>
+			<handlers>
+				<add name="Telerik_Web_UI_WebResource_axd" verb="*" preCondition="integratedMode" path="Telerik.Web.UI.WebResource.axd" type="Telerik.Web.UI.WebResource" /> 
+			</handlers>
+		</system.webServer>
+	</configuration>
+	```
 
 
 	>note By default the image is stored in the Cache. However, if more than one server is used to host the page (web-farm environment) the Session should be used, because if the Cache is used the image is stored locally on the server. When Session is used, the HttpHandler definition (in the .config file) of the **RadCaptcha** should be modified manually by setting the type of the HttpHandler has to be set to **type="Telerik.Web.UI.WebResourceSession"** .
 	
 	>caption web.config
 	
-	**XML**
-	
-		<configuration>
-			<system.web>
-				<httpHandlers>
-					<add path="Telerik.Web.UI.WebResource.axd" type="Telerik.Web.UI.WebResourceSession" verb="*" validate="false" />
-				</httpHandlers>
-			</system.web>
-			<system.webServer>
-				<handlers>
-					<add name="Telerik_Web_UI_WebResource_axd" verb="*" preCondition="integratedMode" path="Telerik.Web.UI.WebResource.axd" type="Telerik.Web.UI.WebResourceSession" />
-				</handlers>
-			</system.webServer>
-		</configuration>
+	```XML
+	<configuration>
+		<system.web>
+			<httpHandlers>
+				<add path="Telerik.Web.UI.WebResource.axd" type="Telerik.Web.UI.WebResourceSession" verb="*" validate="false" />
+			</httpHandlers>
+		</system.web>
+		<system.webServer>
+			<handlers>
+				<add name="Telerik_Web_UI_WebResource_axd" verb="*" preCondition="integratedMode" path="Telerik.Web.UI.WebResource.axd" type="Telerik.Web.UI.WebResourceSession" />
+			</handlers>
+		</system.webServer>
+	</configuration>
+	```
 
 1. In the Properties Window for the **RadCaptcha** control set the following properties:
 

--- a/controls/captcha/troubleshooting/missing-image.md
+++ b/controls/captcha/troubleshooting/missing-image.md
@@ -27,7 +27,7 @@ You should ensure that you have properly defined the HttpHandler that serves the
 
 >caption **Example 1**: Configure the HttpHandler that serves the CAPTCHA image in the web.config file.
 
-**XML**
+```XML
 
 	<configuration>
 		<system.web>
@@ -41,6 +41,7 @@ You should ensure that you have properly defined the HttpHandler that serves the
 			</handlers>
 		</system.webServer>
 	</configuration>
+```
 
 More information is available in the [Getting Started]({%slug captcha/getting-started%}) article.
 
@@ -58,11 +59,12 @@ To resolve the issue, you should ensure the HttpHandler that serves the CAPTCHA 
 
 >caption **Example 2**: Configure the HttpHandler that serves the CAPTCHA image to be requested in a folder that can be accessed by anonymous users.
 
-**ASP.NET**
+```ASP.NET
 
 	<telerik:RadCaptcha ID="RadCaptcha1" Runat="server" ErrorMessage="You have entered an invalid code." 
 		HttpHandlerUrl="~/_layouts/Telerik.Web.UI.WebResource.axd">
 	</telerik:RadCaptcha>
+```
 
 ## Authentication Blockage
 

--- a/controls/chart/advanced-topics/localization-example-using-global-resources,-explicit-expression.md
+++ b/controls/chart/advanced-topics/localization-example-using-global-resources,-explicit-expression.md
@@ -25,30 +25,30 @@ This tutorial will demonstrate localizing the RadChart title using a global reso
 
 1. Paste the following ASP.NET HTML definition of the chart:
 
-	**ASP.NET**
-
-		<telerik:RadChart ID="RadChart1" runat="server">
-		<PlotArea>
-		   <XAxis MaxValue="3" MinValue="1" Step="1"></XAxis>
-		   <YAxis MaxValue="50"></YAxis>
-		</PlotArea>
-		<ChartTitle><TextBlock Text="Sales"></TextBlock></ChartTitle>
-		<Series>
-		   <radC:ChartSeries Name="Series 1">
-			   <items>
-					   <radC:ChartSeriesItem YValue="50">
-						   <Label><TextBlock Text="One"></TextBlock></Label>
-					   </radC:ChartSeriesItem>
-					   <radC:ChartSeriesItem YValue="30">
-						   <Label><TextBlock Text="Two"></TextBlock></Label>
-					   </radC:ChartSeriesItem>
-					   <radC:ChartSeriesItem YValue="20">
-						   <Label><TextBlock Text="Three"></TextBlock></Label>
-					   </radC:ChartSeriesItem>
-				   </items>
-		   </radC:ChartSeries>
-		</Series>
-		</telerik:RadChart> 	
+	```ASP.NET
+	<telerik:RadChart ID="RadChart1" runat="server">
+	<PlotArea>
+	   <XAxis MaxValue="3" MinValue="1" Step="1"></XAxis>
+	   <YAxis MaxValue="50"></YAxis>
+	</PlotArea>
+	<ChartTitle><TextBlock Text="Sales"></TextBlock></ChartTitle>
+	<Series>
+	   <radC:ChartSeries Name="Series 1">
+		   <items>
+			   <radC:ChartSeriesItem YValue="50">
+				   <Label><TextBlock Text="One"></TextBlock></Label>
+			   </radC:ChartSeriesItem>
+			   <radC:ChartSeriesItem YValue="30">
+				   <Label><TextBlock Text="Two"></TextBlock></Label>
+			   </radC:ChartSeriesItem>
+			   <radC:ChartSeriesItem YValue="20">
+				   <Label><TextBlock Text="Three"></TextBlock></Label>
+			   </radC:ChartSeriesItem>
+		   </items>
+	   </radC:ChartSeries>
+	</Series>
+	</telerik:RadChart>
+	```
 
 1. In the Solution Explorer, right-click the project and select **Add** | **Add ASP.NET Folder** | **App_GlobalResources** from the context menu.
 
@@ -62,12 +62,12 @@ This tutorial will demonstrate localizing the RadChart title using a global reso
 
 1. In the ASP.NET HTML markup for the page add the explicit expression "<%$ Resources:MyGlobals, Title %>" to the **Text**attribute for the chart title. The ASP.NET HTML markup for the chart title should now look like this:
 
-	**ASP.NET**
-	
-		<ChartTitle>
-		   <TextBlock Text="<$ Resources>">
-		   </TextBlock>
-		</ChartTitle> 
+	```ASP.NET
+	<ChartTitle>
+	   <TextBlock Text="<$ Resources>">
+	   </TextBlock>
+	</ChartTitle>
+	```
 
 1. Run the application. The chart title should still be "Top Ten Sales".
 

--- a/controls/chart/advanced-topics/localization-example-using-local-resources,-implicit-expression.md
+++ b/controls/chart/advanced-topics/localization-example-using-local-resources,-implicit-expression.md
@@ -25,30 +25,30 @@ This tutorial will demonstrate localizing the RadChart title, series name and ch
 
 1. Paste the following ASP.NET HTML definition of the chart:
 
-	**ASP.NET**
-
-		<telerik:radchart id="RadChart1" runat="server">
-		   <PlotArea>
-			   <XAxis MaxValue="3" MinValue="1" Step="1"></XAxis>
-			   <YAxis MaxValue="50"></YAxis>
-		   </PlotArea>
-		   <ChartTitle><TextBlock Text="Sales"></TextBlock></ChartTitle>
-		   <Series>
-			   <radC:ChartSeries Name="Series 1">
-				   <items>
-						   <radC:ChartSeriesItem YValue="50">
-							   <Label><TextBlock Text="One"></TextBlock></Label>
-						   </radC:ChartSeriesItem>
-						   <radC:ChartSeriesItem YValue="30">
-							   <Label><TextBlock Text="Two"></TextBlock></Label>
-						   </radC:ChartSeriesItem>
-						   <radC:ChartSeriesItem YValue="20">
-							   <Label><TextBlock Text="Three"></TextBlock></Label>
-						   </radC:ChartSeriesItem>
-					   </items>
-			   </radC:ChartSeries>
-		   </Series>
-		</telerik:radchart>
+	```ASP.NET
+	<telerik:radchart id="RadChart1" runat="server">
+	   <PlotArea>
+		   <XAxis MaxValue="3" MinValue="1" Step="1"></XAxis>
+		   <YAxis MaxValue="50"></YAxis>
+	   </PlotArea>
+	   <ChartTitle><TextBlock Text="Sales"></TextBlock></ChartTitle>
+	   <Series>
+		   <radC:ChartSeries Name="Series 1">
+			   <items>
+					   <radC:ChartSeriesItem YValue="50">
+						   <Label><TextBlock Text="One"></TextBlock></Label>
+					   </radC:ChartSeriesItem>
+					   <radC:ChartSeriesItem YValue="30">
+						   <Label><TextBlock Text="Two"></TextBlock></Label>
+					   </radC:ChartSeriesItem>
+					   <radC:ChartSeriesItem YValue="20">
+						   <Label><TextBlock Text="Three"></TextBlock></Label>
+					   </radC:ChartSeriesItem>
+			   </items>
+		   </radC:ChartSeries>
+	   </Series>
+	</telerik:radchart>
+	```
 
 1. In design mode of the Visual Studio 2005 IDE select the menu Tools | Generate Local Resource. Notice that in the Solution Explorer a new "App_LocalResources" folder is created and populated with a resource file named default.aspx.resx.
 
@@ -60,9 +60,9 @@ This tutorial will demonstrate localizing the RadChart title, series name and ch
 
 1. Add the resource key meta:resourcekey="RadChart1Resource1" to the ASP.NET HTML markup for the chart. The RadChart tag should now look like the example below:
 
-	**ASP.NET**
-
-		<telerik:radchart id="RadChart1" runat="server" enableembeddedskins="False" meta:resourcekey="RadChart1Resource1">		
+	```ASP.NET
+	<telerik:radchart id="RadChart1" runat="server" enableembeddedskins="False" meta:resourcekey="RadChart1Resource1">		
+	```
 
 1. In the Solution Explorer, copy "Default.aspx.resx" and name it using the culture code for French, "Default.aspx.fr-FR.resx".
 
@@ -94,30 +94,30 @@ This tutorial will demonstrate localizing the RadChart title, series name and ch
 
 1. Now that the chart title is localized we turn to the series name and item labels.Add another resource key to the ASP.NET HTML markup for the ChartSeries tag "meta:resourcekey="RadChart1Series1Resource1"". The ChartSeries tag will now look like the example below:
 
-	**ASP.NET**
-	     
-		<Series>
-		   <radC:ChartSeries Name="Series 1" meta:resourcekey="RadChart1Series1Resource1">
-		. . . 
+	```ASP.NET
+	<Series>
+	   <radC:ChartSeries Name="Series 1" meta:resourcekey="RadChart1Series1Resource1">
+	. . . 
+	```
 
 1. To each item tag in the ASP.NET HTML markup add another resource key meta:resourceKey="RadChart1Series1Element1Resource1".Name the resource keys "RadChart1Series1Element1Resource1", "RadChart1Series1Element2Resource1" and "RadChart1Series1Element3Resource1" respectively. You will need to add these resource keys for each tag in the HTML that has its own name space.For example, each of the ChartSeriesItem tags is prefixed with the "radC" prefix. The markup should now look like the example below:
 
-	**ASP.NET**
-		
-		<items>
-		   <radC:ChartSeriesItem YValue="50"
-			   meta:resourceKey="RadChart1Series1Element1Resource1">
-			   <Label><TextBlock Text="One"></TextBlock></Label>
-		   </radC:ChartSeriesItem>
-		   <radC:ChartSeriesItem YValue="30"
-			   meta:resourceKey="RadChart1Series1Element2Resource1">
-			   <Label><TextBlock Text="Two"></TextBlock></Label>
-		   </radC:ChartSeriesItem>
-		   <radC:ChartSeriesItem YValue="20"
-			   meta:resourceKey="RadChart1Series1Element3Resource1">
-			   <Label><TextBlock Text="Three"></TextBlock></Label>
-		   </radC:ChartSeriesItem>
-		</items>      
+	```ASP.NET
+	<items>
+	   <radC:ChartSeriesItem YValue="50"
+		   meta:resourceKey="RadChart1Series1Element1Resource1">
+		   <Label><TextBlock Text="One"></TextBlock></Label>
+	   </radC:ChartSeriesItem>
+	   <radC:ChartSeriesItem YValue="30"
+		   meta:resourceKey="RadChart1Series1Element2Resource1">
+		   <Label><TextBlock Text="Two"></TextBlock></Label>
+	   </radC:ChartSeriesItem>
+	   <radC:ChartSeriesItem YValue="20"
+		   meta:resourceKey="RadChart1Series1Element3Resource1">
+		   <Label><TextBlock Text="Three"></TextBlock></Label>
+	   </radC:ChartSeriesItem>
+	</items>      
+	```
 
 1. In the Default.aspx.resx file add the keys and values highlighted in the screen shot below.Notice how the the first part of each name corresponds to the resource key name in the ASP.NET HTML markup followed by the property name.
 

--- a/controls/chart/building-radcharts/creating-radchart-declaratively.md
+++ b/controls/chart/building-radcharts/creating-radchart-declaratively.md
@@ -23,53 +23,53 @@ RadChart properties that are set in the designer can also be written declarative
 
 1. To use the RadChart control on the page you need to declare the namespace and associate a tag prefix. Add the following code just under the "<%@ Page>" tag at the top of the HTML.
 
-	**ASP.NET**
-
-		<%@ register assembly="Telerik.Web.UI" namespace="Telerik.Web.UI" tagprefix="telerik" %>
-		<%@ register assembly="Telerik.Web.UI" namespace="Telerik.Charting" tagprefix="telerik" %>
+	```ASP.NET
+	<%@ register assembly="Telerik.Web.UI" namespace="Telerik.Web.UI" tagprefix="telerik" %>
+	<%@ register assembly="Telerik.Web.UI" namespace="Telerik.Charting" tagprefix="telerik" %>
+	```
 
 1. Within the main div tag for the page add a RadChart tag.
 
-	**ASP.NET**
-
-		<div>
-			<telerik:RadChart runat="Server" id="myRadChart">
-			</telerik:RadChart>
-		</div>
+	```ASP.NET
+	<div>
+		<telerik:RadChart runat="Server" id="myRadChart">
+		</telerik:RadChart>
+	</div>
+	```
 
 1. Within the RadChart tag add a ChartTitle tag and set its TextBlock-Text attribute to "My First Chart".
 
-	**ASP.NET**
-
-		<ChartTitle>
-		<TextBlock Text="My First Chart">
-		</TextBlock>
-		</ChartTitle> 
+	```ASP.NET
+	<ChartTitle>
+	<TextBlock Text="My First Chart">
+	</TextBlock>
+	</ChartTitle>
+	```
 
 1. Add a ChartSeries tag. Set the Name attribute to "Sales".
 
-	**ASP.NET**
-
-		<Series>
-		<telerik:ChartSeries Name="Sales">
-		</telerik:ChartSeries>
-		</Series> 
+	```ASP.NET
+	<Series>
+	<telerik:ChartSeries Name="Sales">
+	</telerik:ChartSeries>
+	</Series>
+	```
 
 1. Add three ChartSeriesItem tags inside the ChartSeries tag as shown in the example below.Set the YValue attribute for each item.Add a TextBlock tag within each ChartSeriesItem tag and set the Text attribute to the values shown in the example.
 
-	**ASP.NET**
-
-		<items>
-		<telerik:ChartSeriesItem YValue="34">
-		<Label><TextBlock Text="Internet"></TextBlock></Label>
-		</telerik:ChartSeriesItem>
-		<telerik:ChartSeriesItem YValue="66">
-		<Label><TextBlock Text="Wholesale"></TextBlock></Label>
-		</telerik:ChartSeriesItem>
-		<telerik:ChartSeriesItem YValue="27">
-		<Label><TextBlock Text="Retail"></TextBlock></Label>
-		</telerik:ChartSeriesItem>
-		</items> 
+	```ASP.NET
+	<items>
+	<telerik:ChartSeriesItem YValue="34">
+	<Label><TextBlock Text="Internet"></TextBlock></Label>
+	</telerik:ChartSeriesItem>
+	<telerik:ChartSeriesItem YValue="66">
+	<Label><TextBlock Text="Wholesale"></Text></Label>
+	</telerik:ChartSeriesItem>
+	<telerik:ChartSeriesItem YValue="27">
+	<Label><TextBlock Text="Retail"></TextBlock></Label>
+	</telerik:ChartSeriesItem>
+	</items>
+	```
 
 	The chart should now look like the figure below. The chart will display as three bars (Bar is the default type).
 
@@ -77,19 +77,18 @@ RadChart properties that are set in the designer can also be written declarative
 
 1. Add an Appearance tag to the RadChart Series tag. Within Appearance add a FillStyle tag, set the MainColor attribute to "Red" and the SecondColor attribute to Maroon. Add a Border tag and set the color to DarkRed.Then add PlotArea tag and Appearance tag within it
 
-	**ASP.NET**
+	```ASP.NET
+	<Appearance>
+	<FillStyle MainColor="Red" SecondColor="Maroon"></FillStyle>
+	<Border Color="DarkRed" />
+	</Appearance>
+	```
 
-		<Appearance>
-		<FillStyle MainColor="Red" SecondColor="Maroon"></FillStyle>
-		<Border Color="DarkRed" />
-		</Appearance> 
-
-	**ASP.NET**
-	
-		<PlotArea>
-		<Appearance>
-		<FillStyle FillType="Solid" MainColor="White"></FillStyle>
-		</Appearance>
+	```ASP.NET
+	<PlotArea>
+	<Appearance>
+	<FillStyle FillType="Solid" MainColor="White"></FillStyle>
+	</Appearance>
 		</PlotArea> 
 
 When complete the chart should look like this example:

--- a/controls/chart/building-radcharts/creating-radchart-programmatically.md
+++ b/controls/chart/building-radcharts/creating-radchart-programmatically.md
@@ -29,69 +29,69 @@ Once the chart is created, the critical steps are creating the [ChartSeries]({%s
 
 1. First add the namespaces that support the objects to be referenced. The Telerik.WebWinControls.UI namespace supports the RadChart declaration and the Telerik.Charting namespace supports the other RadChart objects, e.g. [ChartSeries]({%slug chart/understanding-radchart-elements/series-overview%}) and [ChartSeriesItem]({%slug chart/understanding-radchart-elements/series-items%}).
 
-	**C#**
+	```C#
+	using Telerik.Web.UI;
+	using Telerik.Charting;
+	```
 
-		using Telerik.Web.UI;
-		using Telerik.Charting;		
-
-	**VB**
-
-		Imports Telerik.Web.UI
-		Imports Telerik.Charting
+	```VB
+	Imports Telerik.Web.UI
+	Imports Telerik.Charting
+	```
 
 1. Next construct the RadChart itself. To the RadChart instance, assign the chart title using the ChartTitle.TextBlock.Text property.
 
-	**C#**
-	
-		RadChart radChart = new RadChart();
-		radChart.ChartTitle.TextBlock.Text = "My RadChart";		
+	```C#
+	RadChart radChart = new RadChart();
+	radChart.ChartTitle.TextBlock.Text = "My RadChart";
+	```
 		
-	**VB**
-	
-		Dim radChart As New RadChart()
-		radChart.ChartTitle.TextBlock.Text = "My RadChart"	
+	```VB
+	Dim radChart As New RadChart()
+	radChart.ChartTitle.TextBlock.Text = "My RadChart"
+	```
 
 1. Construct a new [ChartSeries]({%slug chart/understanding-radchart-elements/series-overview%}) object. Assign a name to the [ChartSeries.]({%slug chart/understanding-radchart-elements/series-overview%}) Set the ChartSeries.Type to be **Bar**. Using the ChartSeries.AddItem() method, add a series of [ChartSeriesItem]({%slug chart/understanding-radchart-elements/series-items%}) objects to the series Items collection. AddItem() takes as parameters a double "Value" and a string "Label".
 
-	**C#**
-	
-		// Create a ChartSeries and assign its name and chart type
-		ChartSeries chartSeries = new ChartSeries();
-		chartSeries.Name = "Sales";
-		chartSeries.Type = ChartSeriesType.Bar;
-		// add new items to the series,
-		// passing a value and a label string
-		chartSeries.AddItem(120, "Internet");
-		chartSeries.AddItem(140, "Retail");
-		chartSeries.AddItem(35, "Wholesale");	
+	```C#
+	// Create a ChartSeries and assign its name and chart type
+	ChartSeries chartSeries = new ChartSeries();
+	chartSeries.Name = "Sales";
+	chartSeries.Type = ChartSeriesType.Bar;
+	// add new items to the series,
+	// passing a value and a label string
+	chartSeries.AddItem(120, "Internet");
+	chartSeries.AddItem(140, "Retail");
+	chartSeries.AddItem(35, "Wholesale");
+	```
 		
-	**VB**
-	
-		' Create a ChartSeries and assign its name and chart type
-		Dim chartSeries As New ChartSeries()
-		chartSeries.Name = "Sales"
-		chartSeries.Type = ChartSeriesType.Bar
-		' add new items to the series,
-		' passing a value and a label string
-		chartSeries.AddItem(120, "Internet")
-		chartSeries.AddItem(140, "Retail")
-		chartSeries.AddItem(35, "Wholesale")	
+	```VB
+	' Create a ChartSeries and assign its name and chart type
+	Dim chartSeries As New ChartSeries()
+	chartSeries.Name = "Sales"
+	chartSeries.Type = ChartSeriesType.Bar
+	' add new items to the series,
+	' passing a value and a label string
+	chartSeries.AddItem(120, "Internet")
+	chartSeries.AddItem(140, "Retail")
+	chartSeries.AddItem(35, "Wholesale")
+	```
 
 1. Finally, add the [ChartSeries]({%slug chart/understanding-radchart-elements/series-overview%}) to the RadChart Series collection and add the RadChart to the page.
 
-	**C#**
+	```C#
+	// add the series to the RadChart Series collection
+	radChart.Series.Add(chartSeries);
+	// add the RadChart to the page.
+	this.Page.Controls.Add(radChart);
+	```
 	
-		// add the series to the RadChart Series collection
-			radChart.Series.Add(chartSeries);
-		// add the RadChart to the page.
-			this.Page.Controls.Add(radChart);	
-			
-	**VB**
-	
-		' add the series to the RadChart Series collection
-		radChart.Series.Add(chartSeries)
-		' add the RadChart to the page.
-		Me.Page.Controls.Add(radChart) 	
+	```VB
+	' add the series to the RadChart Series collection
+	radChart.Series.Add(chartSeries)
+	' add the RadChart to the page.
+	Me.Page.Controls.Add(radChart)
+	```
 
 1. The finished chart in the running project should look like this example:
 
@@ -99,16 +99,16 @@ Once the chart is created, the critical steps are creating the [ChartSeries]({%s
 
 	The alternative to using the [ChartSeries]({%slug chart/understanding-radchart-elements/series-overview%}) object constructor and assigning properties is to use the RadChart CreateSeries() method that lets you pass several properties in the call, including Name, MainColor, SecondColor and ChartSeriesType.
 
-	**C#**
-	
-		ChartSeries chartSeries = radChart.CreateSeries("Sales",
-		System.Drawing.Color.RoyalBlue,
-		System.Drawing.Color.LightSteelBlue,
-		ChartSeriesType.Bar);				
+	```C#
+	ChartSeries chartSeries = radChart.CreateSeries("Sales",
+	System.Drawing.Color.RoyalBlue,
+	System.Drawing.Color.LightSteelBlue,
+	ChartSeriesType.Bar);
+	```
 
-	**VB**	
-	
-	    Dim chartSeries As ChartSeries = radChart.CreateSeries("Sales", System.Drawing.Color.RoyalBlue, System.Drawing.Color.LightSteelBlue, ChartSeriesType.Bar)	
+	```VB
+	Dim chartSeries As ChartSeries = radChart.CreateSeries("Sales", System.Drawing.Color.RoyalBlue, System.Drawing.Color.LightSteelBlue, ChartSeriesType.Bar)
+	```
 
 # See Also
 

--- a/controls/checkboxlist/appearance-and-styling/create-a-custom-skin.md
+++ b/controls/checkboxlist/appearance-and-styling/create-a-custom-skin.md
@@ -40,16 +40,16 @@ The second file represents the actual skin of the control, and its name consists
 
 1. Add a new server declaration of **RadCheckBoxList** on your page and set **Skin="MyCustomSkin"** and **EnableEmbeddedSkins="false"**:
 
-	**ASP.NET**
-
-		<telerik:RadCheckBoxList runat="server" ID="RadCheckBoxList1" Skin="MyCustomSkin" EnableEmbeddedSkins="false">
-		</telerik:RadCheckBoxList>
+	```ASP.NET
+	<telerik:RadCheckBoxList runat="server" ID="RadCheckBoxList1" Skin="MyCustomSkin" EnableEmbeddedSkins="false">
+	</telerik:RadCheckBoxList>
+	```
 
 1. Register **Button.MyCustomSkin.css** in the head section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 
-	**ASP.NET**
-
-		<link href="Skins/MyCustomSkinLite/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+	```ASP.NET
+	<link href="Skins/MyCustomSkinLite/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+	```
 
 1. Make sure the path to the files is correct; otherwise the skin will not apply;
 

--- a/controls/checkboxlist/getting-started.md
+++ b/controls/checkboxlist/getting-started.md
@@ -14,74 +14,74 @@ The following help article demonstrates how to set up a page with a **RadCheckBo
 
 1. In the default page of a new ASP.NET AJAX-enabled Web Application, add a **RadCheckBoxList** control:
 
-	**ASP.NET**	
-	
-		<telerik:RadCheckBoxList ID="RadCheckBoxList1" runat="server">
-		</telerik:RadCheckBoxList>
+	```ASP.NET
+	<telerik:RadCheckBoxList ID="RadCheckBoxList1" runat="server">
+	</telerik:RadCheckBoxList>
+	```
 
 1. Add two `ButtonListItem` objects to the `Items` collection and set the appropriate values for `Text` and `Selected` properties of each item:
 
-	**ASP.NET**
-
-		<telerik:RadCheckBoxList ID="RadCheckBoxList1" runat="server">
-			<Items>
-				<telerik:ButtonListItem Text="Accept" Value="0" Selected="true" />
-				<telerik:ButtonListItem Text="Decline" Value="1" />
-			</Items>
-		</telerik:RadCheckBoxList>
+	```ASP.NET
+	<telerik:RadCheckBoxList ID="RadCheckBoxList1" runat="server">
+		<Items>
+			<telerik:ButtonListItem Text="Accept" Value="0" Selected="true" />
+			<telerik:ButtonListItem Text="Decline" Value="1" />
+		</Items>
+	</telerik:RadCheckBoxList>
+	```
 
 1. To hook to the **OnSelectedIndexChanged** server-side event of **RadCheckBoxList**, add an attribute to the main control tag and add the method signature:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadCheckBoxList ID="RadCheckBoxList1" runat="server" OnSelectedIndexChanged="RadCheckBoxList1_SelectedIndexChanged">
+		<Items>
+			<telerik:ButtonListItem Text="Accept" Value="0" Selected="true" />
+			<telerik:ButtonListItem Text="Decline" Value="1" />
+		</Items>
+	</telerik:RadCheckBoxList>
+	```
 
-		<telerik:RadCheckBoxList ID="RadCheckBoxList1" runat="server" OnSelectedIndexChanged="RadCheckBoxList1_SelectedIndexChanged">
-			<Items>
-				<telerik:ButtonListItem Text="Accept" Value="0" Selected="true" />
-				<telerik:ButtonListItem Text="Decline" Value="1" />
-			</Items>
-		</telerik:RadCheckBoxList>
+	```C#
+	protected void RadCheckBoxList1_SelectedIndexChanged(object sender, EventArgs e)
+	{
 
-	**C#**
-	
-		protected void RadCheckBoxList1_SelectedIndexChanged(object sender, EventArgs e)
-		{
+	}
+	```
 
-		}
-
-	**VB.NET**
-	
-		Protected Sub RadCheckBoxList1_SelectedIndexChanged(ByVal sender As Object, ByVal e As EventArgs)
-		End Sub
+	```VB
+	Protected Sub RadCheckBoxList1_SelectedIndexChanged(ByVal sender As Object, ByVal e As EventArgs)
+	End Sub
+	```
 
 1. Add a Label control to write the information to:
 
-	**ASP.NET**
-
-		<asp:Label ID="Label1" Text="" runat="server" />
+	```ASP.NET
+	<asp:Label ID="Label1" Text="" runat="server" />
+	```
 
 1. Use the **OnSelectedIndexChanged** event handler to write information about the properties of the `SelectedItem` of the `RadCheckBoxList`:
 
-	**C#**
-	
-		protected void RadCheckBoxList1_SelectedIndexChanged(object sender, EventArgs e)
-		{
-			RadCheckBoxList checkboxlist = sender as RadCheckBoxList;
+	```C#
+	protected void RadCheckBoxList1_SelectedIndexChanged(object sender, EventArgs e)
+	{
+		RadCheckBoxList checkboxlist = sender as RadCheckBoxList;
 
 
 			string data = string.Format("selected index: {0}, selected value {1}, selected text: {2}",
 										checkboxlist.SelectedIndex, checkboxlist.SelectedValue, checkboxlist.SelectedItem.Text);
-			Label1.Text = data;
-		}
+		Label1.Text = data;
+	}
+	```
 
-	**VB.NET**
-	
-		Protected Sub RadCheckBoxList1_SelectedIndexChanged(sender As Object, e As EventArgs)
-			Dim checkboxlist As RadCheckBoxList = TryCast(sender, RadCheckBoxList)
+	```VB
+	Protected Sub RadCheckBoxList1_SelectedIndexChanged(sender As Object, e As EventArgs)
+		Dim checkboxlist As RadCheckBoxList = TryCast(sender, RadCheckBoxList)
 
 
 			Dim data As String = String.Format("selected index: {0}, selected value {1}, selected text: {2}", checkboxlist.SelectedIndex, checkboxlist.SelectedValue, checkboxlist.SelectedItem.Text)
-			Label1.Text = data
-		End Sub
+		Label1.Text = data
+	End Sub
+	```
 
 
 

--- a/controls/checkboxlist/mobile-support/render-modes.md
+++ b/controls/checkboxlist/mobile-support/render-modes.md
@@ -21,24 +21,24 @@ There are two ways to configure the rendering mode of the controls:
 
 * The **RenderMode property** in the markup or in the code-behind that can be used for a particular instance:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadCheckBoxList ID="RadCheckBoxList1" runat="server" RenderMode="Lightweight">
+		<Items>
+			<telerik:ButtonListItem Text="English" Selected="true" />
+			<telerik:ButtonListItem Text="German" />
+			<telerik:ButtonListItem Text="French" />
+		</Items>
+	</telerik:RadCheckBoxList>
+	```
 
-		<telerik:RadCheckBoxList ID="RadCheckBoxList1" runat="server" RenderMode="Lightweight">
-			<Items>
-				<telerik:ButtonListItem Text="English" Selected="true" />
-				<telerik:ButtonListItem Text="German" />
-				<telerik:ButtonListItem Text="French" />
-			</Items>
-		</telerik:RadCheckBoxList>
 
+	```C#
+	RadCheckBoxList1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	```
 
-	**C#**
-
-		RadCheckBoxList1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-
-	**VB**
-
-		RadCheckBoxList1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```VB
+	RadCheckBoxList1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```
 
 
 * A **global setting in the web.config** file that will affect the entire application, unless a concrete value is specified for a given control instance:

--- a/controls/clientexportmanager/how-to/exporting-special-characters.md
+++ b/controls/clientexportmanager/how-to/exporting-special-characters.md
@@ -62,73 +62,45 @@ Here is a process of how to define a font that contains the desired symbols for 
 
 1. Add the font to the **PdfSettings.Fonts** collection. 
 
-    **C#**
+    ```C#
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        RadClientExportManager1.PdfSettings.Fonts.Add("Arial Unicode MS", "Fonts/ArialUnicodeMS.ttf");
+    }
+    ```
 
-        protected void Page_Load(object sender, EventArgs e)
-        {
-            RadClientExportManager1.PdfSettings.Fonts.Add("Arial Unicode MS", "Fonts/ArialUnicodeMS.ttf");
-        }
-
-    **VB**
-
+    ```VB
     Protected Sub Page_Load(sender As Object, e As EventArgs)
         RadClientExportManager1.PdfSettings.Fonts.Add("Arial Unicode MS", "Fonts/ArialUnicodeMS.ttf")
     End Sub
+    ```
 
 1. Apply the font to the `<div>` "foo":
 
-    **CSS**
-
-        #foo {
-            font-family: 'Arial Unicode MS';
-            background-color: grey;
-            color: white;
-        }
+    ```CSS
+    #foo {
+        font-family: 'Arial Unicode MS';
+        background-color: grey;
+        color: white;
+    }
+    ```
 
 1. Export the `<div>`:
 
-    **ASP.NET**
+    ```ASP.NET
+    <telerik:RadClientExportManager runat="server" ID="RadClientExportManager1">
+        <pdfsettings filename="Myfile.pdf" />
+    </telerik:RadClientExportManager>
+    <input type="button" onclick="exportElement()" value="export" />
 
-        <telerik:RadClientExportManager runat="server" ID="RadClientExportManager1">
-            <pdfsettings filename="Myfile.pdf" />
-        </telerik:RadClientExportManager>
-        <input type="button" onclick="exportElement()" value="export" />
+    <script type="text/javascript">
+        function exportElement() {
+            var exp = $find("<%= RadClientExportManager1.ClientID %>");
+            exp.exportPDF($telerik.$("#foo"));
+        }
+    </script>
+    ```
 
-        <script type="text/javascript">
-            function exportElement() {
-                var exp = $find("<%= RadClientExportManager1.ClientID %>");
-                exp.exportPDF($telerik.$("#foo"));
-            }
-        </script>
-
-
-1. **Result**: The special characters are correctly exported and visible in the PDF file:
-
-    ![Special Characters Exported](images/clientexportmanager-special-characters-exported.png)
-
-
->important Some of the popular fonts (Segoe UI, Arial Unicode MS, Noto Serif) by default do not support the bold font. In the browser you see it working since there are many fonts the browser can fall back to, however, the exported content is not able to fall back to any font.
-To be able to export the bold text, you will need to add the bold font to the collection. Bold font for Segoe and bold font for Arial Unicode, etc.
->
-
-## Tips on defining fonts
-
-Defining a `@font-face` element in the CSS of the page is equivalent to populating the `Fonts` collection. For example:
-
-````CSS
-@font-face {
-   font-family: 'Arial Unicode MS';
-   src: url('Fonts/Arial Unicode MS.ttf');
-}
-````
-
-You can define the special font for the global PDF export through specific CSS classes that are added to it. This means you can have it rendered on the page according to the page/browser styleshets and only change the font for export without any additional code in your markup.
- 
-````CSS
- .k-pdf-export, .k-pdf-export * {
-    font-family: 'Arial Unicode MS';
- }
-````
 
 
 

--- a/controls/cloudupload/cloud-storage-providers/amazon-s3.md
+++ b/controls/cloudupload/cloud-storage-providers/amazon-s3.md
@@ -58,15 +58,15 @@ Depending on the Telerik.Web.UI.dll version you use, you need to use a different
 
 1. In the **Configuration Wizard** dialog enter Amazon S3 **Access Key**, **Secret Key** and **Bucket Name**. ![cloudupload-amazon-s 3-configuration](images/cloudupload-amazon-s3-configuration.png)Specifying the **Uncommitted Files Expiration Period**(TimeSpan Structure), you could easily configure the time, after which the unprocessed files will be removed from the storage.When **Ensure Container** is checked, the control will create a new Bucket if it doesn't exist. In case it is not checked and the Bucket doesn't exist - an exception will be thrown.This will add configuration setting in the **web.config** file:
 
-	**XML**
-	
-		<telerik.web.ui>
-			<radCloudUpload>
-				<storageProviders>
-					<add name="Amazon" type="Telerik.Web.UI.AmazonS3Provider" accessKey="" secretKey="" bucketName="" uncommitedFilesExpirationPeriod="2" />
-				</storageProviders>
-			</radCloudUpload>
-		</telerik.web.ui>
+	```XML
+	<telerik.web.ui>
+		<radCloudUpload>
+			<storageProviders>
+				<add name="Amazon" type="Telerik.Web.UI.AmazonS3Provider" accessKey="" secretKey="" bucketName="" uncommitedFilesExpirationPeriod="2" />
+			</storageProviders>
+		</radCloudUpload>
+	</telerik.web.ui>
+	```
 
 
 >caution Uploading files in Amazon S3 is performed in chunks. Default chunk size defined by Amazon is 5 MB. Because the default ASP.NET size request is 4MB, you must increase it, in order to avoid errors. This can be done by increasing the value of [MaxRequestLength]({%slug cloudupload/how-to/uploading-large-files%}) property. Chunks which are not uploaded will be removed automatically by **RadCloudUpload** .

--- a/controls/cloudupload/custom-cloud-storage-providers/custom-amazon-s3-provider.md
+++ b/controls/cloudupload/custom-cloud-storage-providers/custom-amazon-s3-provider.md
@@ -22,94 +22,94 @@ Common scenario is the need to upload files depending on the user's Geo location
 
 1. Create a new class, which inherits the **AmazonS3Provider** class and override its **Initialize** method. In this method you can set all credentials:
 
-	**C#**
-	
-		using System;
-		using System.Linq;
-		using Telerik.Web.UI;
-		using Amazon.S3;
-	
-		namespace SampleNamespace
+	```C#
+	using System;
+	using System.Linq;
+	using Telerik.Web.UI;
+	using Amazon.S3;
+
+	namespace SampleNamespace
+	{
+		public class CustomAmazonProvider : AmazonS3Provider
 		{
-			public class CustomAmazonProvider : AmazonS3Provider
+			public override void Initialize(string name, System.Collections.Specialized.NameValueCollection config)
 			{
-				public override void Initialize(string name, System.Collections.Specialized.NameValueCollection config)
-				{
-					AccessKey = "{ACCESS_KEY}";
-					SecretKey = "{SECRET_KEY}";
-					BucketName = "{BUCKET_NAME}";
-					UncommitedFilesExpirationPeriod = TimeSpan.FromHours(2);
-				}
-	
-				//Override this method only if you want to set the Region Endpoint
-				public override void EnsureWebClient()
-				{
-					//Set the Region Endpoint http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-					AmazonS3Client client = new AmazonS3Client(AccessKey, SecretKey, Amazon.RegionEndpoint.APSoutheast2);
-					//The newly created client object must be assigned to AmazonS3Client
-					AmazonS3Client = client;
-				}
+				AccessKey = "{ACCESS_KEY}";
+				SecretKey = "{SECRET_KEY}";
+				BucketName = "{BUCKET_NAME}";
+				UncommitedFilesExpirationPeriod = TimeSpan.FromHours(2);
+			}
+
+			//Override this method only if you want to set the Region Endpoint
+			public override void EnsureWebClient()
+			{
+				//Set the Region Endpoint http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+				AmazonS3Client client = new AmazonS3Client(AccessKey, SecretKey, Amazon.RegionEndpoint.APSoutheast2);
+				//The newly created client object must be assigned to AmazonS3Client
+				AmazonS3Client = client;
 			}
 		}
+	}
+	```
 	
-	**VB.NET**
-	
-		Imports System
-		Imports System.Linq
-		Imports Telerik.Web.UI
-		Imports Amazon.S3
-	
-		Namespace SampleNamespace
-	
-			Public Class CustomAmazonProvider
-				Inherits AmazonS3Provider
-	
-				Public Overrides Sub Initialize(name As String, config As System.Collections.Specialized.NameValueCollection)
-					AccessKey = "{ACCESS_KEY}"
-					SecretKey = "{SECRET_KEY}"
-					BucketName = "{BUCKET_NAME}"
-				End Sub
-	
-				'Override this method only if you want to set the Region Endpoint
-				Public Overrides Sub EnsureWebClient()
-					'Set the Region Endpoint http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-					Dim client As New AmazonS3Client(AccessKey, SecretKey, Amazon.RegionEndpoint.APSoutheast2)
-					'The newly created client object must be assigned to AmazonS3Client
-					AmazonS3Client = client
-				End Sub
-	
-			End Class
-		End Namespace
+	```VB
+	Imports System
+	Imports System.Linq
+	Imports Telerik.Web.UI
+	Imports Amazon.S3
+
+	Namespace SampleNamespace
+
+		Public Class CustomAmazonProvider
+			Inherits AmazonS3Provider
+
+			Public Overrides Sub Initialize(name As String, config As System.Collections.Specialized.NameValueCollection)
+				AccessKey = "{ACCESS_KEY}"
+				SecretKey = "{SECRET_KEY}"
+				BucketName = "{BUCKET_NAME}"
+			End Sub
+
+			'Override this method only if you want to set the Region Endpoint
+			Public Overrides Sub EnsureWebClient()
+				'Set the Region Endpoint http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+				Dim client As New AmazonS3Client(AccessKey, SecretKey, Amazon.RegionEndpoint.APSoutheast2)
+				'The newly created client object must be assigned to AmazonS3Client
+				AmazonS3Client = client
+			End Sub
+
+		End Class
+	End Namespace
+	```
 
 
 2. Add new storage provider in the configuration file as you set the new **Type**.
 
-	**XML**
-	
-		<?xml version="1.0" encoding="utf-8" ?>
-		<configuration>
-			<configSections>
-				<sectionGroup name="telerik.web.ui">
-					<section name="radCloudUpload" type="Telerik.Web.UI.CloudUploadConfigurationSection" allowDefinition="MachineToApplication" requirePermission="false" />
-				</sectionGroup>
-			</configSections>
-		 ...
-			<telerik.web.ui>
-				<radCloudUpload>
-					<storageProviders>
-						<!-- Add a new storage with a Type of the Custom Provider. Note that the Type is a combination of the name space and the class name. -->
-						<add name="Amazon" type="SampleNamespace.CustomAmazonProvider"/>
-					</storageProviders>
-				</radCloudUpload>
-			</telerik.web.ui>
-		</configuration>
+	```XML
+	<?xml version="1.0" encoding="utf-8" ?>
+	<configuration>
+		<configSections>
+			<sectionGroup name="telerik.web.ui">
+				<section name="radCloudUpload" type="Telerik.Web.UI.CloudUploadConfigurationSection" allowDefinition="MachineToApplication" requirePermission="false" />
+			</sectionGroup>
+		</configSections>
+	 ...
+		<telerik.web.ui>
+			<radCloudUpload>
+				<storageProviders>
+					<!-- Add a new storage with a Type of the Custom Provider. Note that the Type is a combination of the name space and the class name. -->
+					<add name="Amazon" type="SampleNamespace.CustomAmazonProvider"/>
+				</storageProviders>
+			</radCloudUpload>
+		</telerik.web.ui>
+	</configuration>
+	```
 
 
 3. Define the **CloudUpload** and set Amazon as a **ProviderType**.
 
-	**ASP.NET**
-	
-		<telerik:RadCloudUpload ID="RadCloudUpload1" runat="server" ProviderType="Amazon"></telerik:RadCloudUpload>
+	```ASP.NET
+	<telerik:RadCloudUpload ID="RadCloudUpload1" runat="server" ProviderType="Amazon"></telerik:RadCloudUpload>
+	```
 	
 
 
@@ -121,127 +121,126 @@ Amazon providers. For example files uploading in different Geo Locations.
 1. Create a as many Custom Providers as you need. They must inherit the **AmazonS3Provider** class. Override their **Initialize** method.
 
 
-	**C#**
-	
-		using System;
-		using System.Linq;
-		using Telerik.Web.UI;
-		using Amazon.S3;
-	
-		namespace SampleNamespace
-		{
-			public class CustomAmazonProvider1 : AmazonS3Provider
-			{
-				public override void Initialize(string name, System.Collections.Specialized.NameValueCollection config)
-				{
-					AccessKey = "{ACCESS_KEY}";
-					SecretKey = "{SECRET_KEY}";
-					BucketName = "{BUCKET_NAME}";
-					UncommitedFilesExpirationPeriod = TimeSpan.FromHours(2);
-				}
-			}
-		}	
-	**VB.NET**
-	
-		Imports System
-		Imports System.Linq
-		Imports Telerik.Web.UI
-		Imports Amazon.S3
-	
-		Namespace SampleNamespace
-	
-			Public Class CustomAmazonProvider1
-				Inherits AmazonS3Provider
-	
-				Public Overrides Sub Initialize(name As String, config As System.Collections.Specialized.NameValueCollection)
-					AccessKey = "{ACCESS_KEY}"
-					SecretKey = "{SECRET_KEY}"
-					BucketName = "{BUCKET_NAME}"
-					UncommitedFilesExpirationPeriod = TimeSpan.FromHours(2)
-				End Sub
-	
-			End Class
-		End Namespace
+	```C#
+	using System;
+	using System.Linq;
+	using Telerik.Web.UI;
+	using Amazon.S3;
 
-	**C#**
-	
-		using System;
-		using System.Linq;
-		using Telerik.Web.UI;
-		using Amazon.S3;
-	
-		namespace SampleNamespace
+	namespace SampleNamespace
+	{
+		public class CustomAmazonProvider1 : AmazonS3Provider
 		{
-			public class CustomAmazonProvider2 : AmazonS3Provider
+			public override void Initialize(string name, System.Collections.Specialized.NameValueCollection config)
 			{
-				public override void Initialize(string name, System.Collections.Specialized.NameValueCollection config)
-				{
-					//Values from the config NameValueCollection are passed from the web.config file.
-					AccessKey = config["accessKey"];
-					SecretKey = config["secretKey"];
-					BucketName = config["bucketName"];
-					UncommitedFilesExpirationPeriod = config["uncommitedFilesExpirationPeriod"];
-				}
+				AccessKey = "{ACCESS_KEY}";
+				SecretKey = "{SECRET_KEY}";
+				BucketName = "{BUCKET_NAME}";
+				UncommitedFilesExpirationPeriod = TimeSpan.FromHours(2);
 			}
 		}
+	}
+	```
+	```VB
+	Imports System
+	Imports System.Linq
+	Imports Telerik.Web.UI
+	Imports Amazon.S3
 
+	Namespace SampleNamespace
 
-	**VB.NET**
-	
-		Imports System
-		Imports System.Linq
-		Imports Telerik.Web.UI
-		Imports Amazon.S3
-	
-		Namespace SampleNamespace
-	
-			Public Class CustomAmazonProvider2
-				Inherits AmazonS3Provider
-	
-				Public Overrides Sub Initialize(name As String, config As System.Collections.Specialized.NameValueCollection)
-					'Values from the config NameValueCollection are passed from the web.config file.
-					AccessKey = config("accessKey")
-					SecretKey = config("secretKey")
-					BucketName = config("bucketName")
-					UncommitedFilesExpirationPeriod = config("uncommitedFilesExpirationPeriod")
-				End Sub
-	
-			End Class
-		End Namespace
+		Public Class CustomAmazonProvider1
+			Inherits AmazonS3Provider
+
+			Public Overrides Sub Initialize(name As String, config As System.Collections.Specialized.NameValueCollection)
+				AccessKey = "{ACCESS_KEY}"
+				SecretKey = "{SECRET_KEY}"
+				BucketName = "{BUCKET_NAME}"
+				UncommitedFilesExpirationPeriod = TimeSpan.FromHours(2)
+			End Sub
+
+		End Class
+	End Namespace
+	```
+
+	```C#
+	using System;
+	using System.Linq;
+	using Telerik.Web.UI;
+	using Amazon.S3;
+
+	namespace SampleNamespace
+	{
+		public class CustomAmazonProvider2 : AmazonS3Provider
+		{
+			public override void Initialize(string name, System.Collections.Specialized.NameValueCollection config)
+			{
+				//Values from the config NameValueCollection are passed from the web.config file.
+				AccessKey = config["accessKey"];
+				SecretKey = config["secretKey"];
+				BucketName = config["bucketName"];
+				UncommitedFilesExpirationPeriod = config["uncommitedFilesExpirationPeriod"];
+			}
+		}
+	}
+	```
+
+	```VB
+	Imports System
+	Imports System.Linq
+	Imports Telerik.Web.UI
+	Imports Amazon.S3
+
+	Namespace SampleNamespace
+
+		Public Class CustomAmazonProvider2
+			Inherits AmazonS3Provider
+
+			Public Overrides Sub Initialize(name As String, config As System.Collections.Specialized.NameValueCollection)
+				'Values from the config NameValueCollection are passed from the web.config file.
+				AccessKey = config("accessKey")
+				SecretKey = config("secretKey")
+				BucketName = config("bucketName")
+				UncommitedFilesExpirationPeriod = config("uncommitedFilesExpirationPeriod")
+			End Sub
+
+		End Class
+	End Namespace
+	```
 	
 
 
 2. Register the newly created Custom Providers in the configuration file:
 
-	**XML**
-	
-		<?xml version="1.0" encoding="utf-8" ?>
-		<configuration>
-			<configSections>
-				<sectionGroup name="telerik.web.ui">
-					<section name="radCloudUpload" type="Telerik.Web.UI.CloudUploadConfigurationSection" allowDefinition="MachineToApplication" requirePermission="false" />
-				</sectionGroup>
-			</configSections>
-		 ...
-			<telerik.web.ui>
-				<radCloudUpload>
-					<storageProviders>
-						<!-- Add a new storage providers with a Type of the Custom Provider. Note that the Type is a combination of the name space and the class name. -->
-						<add name="CustomAmazonProvider1" type="SampleNamespace.CustomAmazonProvider1"/>
-						<add name="CustomAmazonProvider2" type="SampleNamespace.CustomAmazonProvider2" accessKey="{ACCESS_KEY}" secretKey="{SECRET_KEY}" bucketName="{BUCKET_NAME}" subFolderStructure="{SUB_FOLDER_STRUCTURE}" uncommitedFilesExpirationPeriod="2"/>
-					</storageProviders>
-				</radCloudUpload>
-			</telerik.web.ui>
-		</configuration>
+	```XML
+	<?xml version="1.0" encoding="utf-8" ?>
+	<configuration>
+		<configSections>
+			<sectionGroup name="telerik.web.ui">
+				<section name="radCloudUpload" type="Telerik.Web.UI.CloudUploadConfigurationSection" allowDefinition="MachineToApplication" requirePermission="false" />
+			</sectionGroup>
+		</configSections>
+	 ...
+		<telerik.web.ui>
+			<radCloudUpload>
+				<storageProviders>
+					<!-- Add a new storage providers with a Type of the Custom Provider. Note that the Type is a combination of the name space and the class name. -->
+					<add name="CustomAmazonProvider1" type="SampleNamespace.CustomAmazonProvider1"/>
+					<add name="CustomAmazonProvider2" type="SampleNamespace.CustomAmazonProvider2" accessKey="{ACCESS_KEY}" secretKey="{SECRET_KEY}" bucketName="{BUCKET_NAME}" subFolderStructure="{SUB_FOLDER_STRUCTURE}" uncommitedFilesExpirationPeriod="2"/>
+				</storageProviders>
+			</radCloudUpload>
+		</telerik.web.ui>
+	</configuration>
+	```
 
 
 
 
 3. Add a new **CloudUpload** control with **ProviderType** Amazon and set the **HttpHandlerUrl** property.
 
-	**ASP.NET**
-	
-		<telerik:RadCloudUpload ID="RadCloudUpload2" runat="server" ProviderType="Amazon" HttpHandlerUrl="~/Handler.ashx" ></telerik:RadCloudUpload>
+	```ASP.NET
+	<telerik:RadCloudUpload ID="RadCloudUpload2" runat="server" ProviderType="Amazon" HttpHandlerUrl="~/Handler.ashx" ></telerik:RadCloudUpload>
+	```
 	
 
 
@@ -249,48 +248,48 @@ Amazon providers. For example files uploading in different Geo Locations.
 
 
 
-	**C#**
+	```C#
+	<%@ WebHandler Language="C#" Class="CloudUploadHandler" %>
 	
-		<%@ WebHandler Language="C#" Class="CloudUploadHandler" %>
-		
-		using System;
-		using System.Web;
-		
-		public class CloudUploadHandler : Telerik.Web.UI.CloudUploadHandler 
+	using System;
+	using System.Web;
+	
+	public class CloudUploadHandler : Telerik.Web.UI.CloudUploadHandler
+	{
+		public override void SetCustomProvider(object sender, Telerik.Web.UI.CloudUpload.CustomProviderSetupEventArgs e)
 		{
-			public override void SetCustomProvider(object sender, Telerik.Web.UI.CloudUpload.CustomProviderSetupEventArgs e)
+			//Check for some condition and select Custom Provider
+			if (true)
 			{
-				//Check for some condition and select Custom Provider
-				if (true)
-				{
-					e.Name = "CustomAmazonProvider2";
-				}
-				else
-				{
-					e.Name = "CustomAmazonProvider1";
-				}
+				e.Name = "CustomAmazonProvider2";
+			}
+			else
+			{
+				e.Name = "CustomAmazonProvider1";
 			}
 		}
+	}
+	```
 
-	**VB.NET**
+	```VB
+	<%@ WebHandler Language="VB" Class="CloudUploadHandler" %>
+	Imports System
+	Imports System.Web
+	Imports Telerik.Web.UI
 	
-		<%@ WebHandler Language="VB" Class="CloudUploadHandler" %>
-		Imports System
-		Imports System.Web
-		Imports Telerik.Web.UI
-		
-		Public Class CloudUploadHandler
-			Inherits Telerik.Web.UI.CloudUploadHandler
-		
-			Public Overrides Sub SetCustomProvider(sender As Object, e As Telerik.Web.UI.CloudUpload.CustomProviderSetupEventArgs)
-				'Check for some condition and select Custom Provider
-				If True Then
-					e.Name = "CustomAmazonProvider2"
-				Else
-					e.Name = "CustomAmazonProvider1"
-				End If
-			End Sub
-		End Class
+	Public Class CloudUploadHandler
+		Inherits Telerik.Web.UI.CloudUploadHandler
+	
+		Public Overrides Sub SetCustomProvider(sender As Object, e As Telerik.Web.UI.CloudUpload.CustomProviderSetupEventArgs)
+			'Check for some condition and select Custom Provider
+			If True Then
+				e.Name = "CustomAmazonProvider2"
+			Else
+				e.Name = "CustomAmazonProvider1"
+			End If
+		End Sub
+	End Class
+	```
 
 
 # See Also

--- a/controls/cloudupload/how-to/uploading-large-files.md
+++ b/controls/cloudupload/how-to/uploading-large-files.md
@@ -64,8 +64,7 @@ Modify the configuration file to allow uploads of files of up to 100MB and uploa
 
 1. Add these lines in the **Web.config** file:
 
-	**XML**
-	
+	```XML
 	<system.webserver>
 		...
 		<security>
@@ -74,6 +73,7 @@ Modify the configuration file to allow uploads of files of up to 100MB and uploa
 			</requestFiltering>
 		</security>
 	</system.webserver>
+	```
 		
 
 

--- a/controls/cloudupload/how-to/using-multiple-accounts-for-one-cloud-storage-provider.md
+++ b/controls/cloudupload/how-to/using-multiple-accounts-for-one-cloud-storage-provider.md
@@ -22,17 +22,17 @@ In some scenarios it is needed to upload files in multiple accounts or container
 
 1. Change the allow definition for the **RadCloudUpload** section in the web.config of the root folder to "Everywhere":
 
-	**XML**
-	
-		<?xml version="1.0"?>
-		<configuration>
-			<configSections>
-				<sectionGroup name="telerik.web.ui">
-					<section name="radCloudUpload" type="Telerik.Web.UI.CloudUploadConfigurationSection" allowDefinition="Everywhere" requirePermission="false"/>
-				</sectionGroup>
-			</configSections>
-			...
-		</configuration>
+	```XML
+	<?xml version="1.0"?>
+	<configuration>
+		<configSections>
+			<sectionGroup name="telerik.web.ui">
+				<section name="radCloudUpload" type="Telerik.Web.UI.CloudUploadConfigurationSection" allowDefinition="Everywhere" requirePermission="false"/>
+			</sectionGroup>
+		</configSections>
+		...
+	</configuration>
+	```
 
 
 2. Create a new folder
@@ -46,23 +46,23 @@ In some scenarios it is needed to upload files in multiple accounts or container
 
 6. Configure the web.config in the newly added folder:
 
-	**XML**
-	
-		<?xml version="1.0" ?>
-		<configuration>
-		<system.web>
-		</system.web>
-		<telerik.web.ui>
-			<radCloudUpload>
-				<storageProviders>
-					<!--Remove the existing provider from the web.config of the root folder.
-					If it is not set then the next row is not needed.-->
-					<remove name="Amazon"/>
-					<add name="Amazon" type="Telerik.Web.UI.AmazonS3Provider" accessKey="" secretKey="" bucketName="" subFolderStructure="" uncommitedFilesExpirationPeriod="2" />
-				</storageProviders>
-			</radCloudUpload>
-		</telerik.web.ui>
-		</configuration>
+	```XML
+	<?xml version="1.0" ?>
+	<configuration>
+	<system.web>
+	</system.web>
+	<telerik.web.ui>
+		<radCloudUpload>
+			<storageProviders>
+				<!--Remove the existing provider from the web.config of the root folder.
+				If it is not set then the next row is not needed.-->
+				<remove name="Amazon"/>
+				<add name="Amazon" type="Telerik.Web.UI.AmazonS3Provider" accessKey="" secretKey="" bucketName="" subFolderStructure="" uncommitedFilesExpirationPeriod="2" />
+			</storageProviders>
+		</radCloudUpload>
+	</telerik.web.ui>
+	</configuration>
+	```
 
 
 
@@ -70,35 +70,35 @@ In some scenarios it is needed to upload files in multiple accounts or container
 
 
 
-	**C#**
-		
-		<%@ WebHandler Language="C#" Class="Handler" %>
-		using System;
-		using System.Web;
-		using Telerik.Web.UI;
-	
-		public class Handler : CloudUploadHandler
-		{
-		}
-	**VB.NET**
-		
-		<%@ WebHandler Language="VB" Class="Handler" %>
-	
-		Imports System
-		Imports System.Web
-		Imports Telerik.Web.UI
-	
-		Public Class Handler : Inherits CloudUploadHandler
-		End Class
+	```C#
+	<%@ WebHandler Language="C#" Class="Handler" %>
+	using System;
+	using System.Web;
+	using Telerik.Web.UI;
+
+	public class Handler : CloudUploadHandler
+	{
+	}
+	```
+	```VB
+	<%@ WebHandler Language="VB" Class="Handler" %>
+
+	Imports System
+	Imports System.Web
+	Imports Telerik.Web.UI
+
+	Public Class Handler : Inherits CloudUploadHandler
+	End Class
+	```
 
 
 
 8. Add **RadCloudUpload** control to the form and configure it to use the added custom handler:
 
-	**ASP.NET**
-	
-		<telerik:RadCloudUpload ID="RadCloudUpload2" runat="server" ProviderType="Amazon" HttpHandlerUrl="~/AmazonS3Bucket1/Handler.ashx">
-		</telerik:RadCloudUpload>
+	```ASP.NET
+	<telerik:RadCloudUpload ID="RadCloudUpload2" runat="server" ProviderType="Amazon" HttpHandlerUrl="~/AmazonS3Bucket1/Handler.ashx">
+	</telerik:RadCloudUpload>
+	```
 	
 
 # See Also

--- a/controls/diagram/getting-started.md
+++ b/controls/diagram/getting-started.md
@@ -22,11 +22,11 @@ The following tutorial demonstrates how you can add a simple **RadDiagram** cont
 	
 	>caption **Example 1**: Declaration of a **RadDiagram** control.
 
-	**ASP.NET**
-
-		<asp:ScriptManager runat="server" ID="ScriptManager1"  />
-		<telerik:RadDiagram ID="RadDiagram1" runat="server">
-		</telerik:RadDiagram>
+	```ASP.NET
+	<asp:ScriptManager runat="server" ID="ScriptManager1"  />
+	<telerik:RadDiagram ID="RadDiagram1" runat="server">
+	</telerik:RadDiagram>
+	```
 
 1. Add a few shapes in the **ShapesCollection** of the diagram. It is recommended to set different values for their **X** and **Y** properties so that they are not positioned on the same location.
 
@@ -36,11 +36,10 @@ The following tutorial demonstrates how you can add a simple **RadDiagram** cont
 
 	>caption **Example 2**: The diagram now contains several shapes
 
-	**ASP.NET**
-
-		<asp:ScriptManager runat="server" ID="ScriptManager1"  />
-		<telerik:RadDiagram ID="RadDiagram1" runat="server">
-			<ShapesCollection>
+	```ASP.NET
+	<asp:ScriptManager runat="server" ID="ScriptManager1"  />
+	<telerik:RadDiagram ID="RadDiagram1" runat="server">
+		<ShapesCollection>
 				<telerik:DiagramShape Id="DiagramShape5" Width="100" Height="70" X="260" Y="100" Type="rectangle">
 					<ContentSettings Text="Parent" />
 					<FillSettings Color="#25a0da" />
@@ -58,7 +57,8 @@ The following tutorial demonstrates how you can add a simple **RadDiagram** cont
 					<FillSettings Color="#FFBE33" />
 				</telerik:DiagramShape>
 			</ShapesCollection>
-		</telerik:RadDiagram>
+	</telerik:RadDiagram>
+	```
 
 1. Add some connections between the shapes in the diagram to the **ConnectionsCollections**. It is important to specify valid shapes from which a connection starts and to which it ends. If the **ShapeId** property in **FromSettings** and **ToSettings** contains an Id of a non-existent shape, the connection will not be created.
 
@@ -68,11 +68,10 @@ The following tutorial demonstrates how you can add a simple **RadDiagram** cont
 
 	>caption **Example 3**: The shapes in the diagram are connected
 
-	**ASP.NET**
-
-		<asp:ScriptManager runat="server" ID="ScriptManager1"  />
-		<telerik:RadDiagram ID="RadDiagram1" runat="server">
-			<ShapesCollection>
+	```ASP.NET
+	<asp:ScriptManager runat="server" ID="ScriptManager1"  />
+	<telerik:RadDiagram ID="RadDiagram1" runat="server">
+		<ShapesCollection>
 				<telerik:DiagramShape Id="DiagramShape1" Width="100" Height="70" X="260" Y="100" Type="rectangle">
 					<ContentSettings Text="Parent" />
 					<FillSettings Color="#25a0da" />

--- a/controls/dock/how-to/adding-controls-inside-dynamically-created-docks.md
+++ b/controls/dock/how-to/adding-controls-inside-dynamically-created-docks.md
@@ -5,18 +5,12 @@ description: Check our Web Forms article about Adding Controls Inside Dynamicall
 slug: dock/how-to/adding-controls-inside-dynamically-created-docks
 tags: adding,controls,inside,dynamically,created,docks
 published: True
-position: 1
+position: 3
 ---
 
 # Adding Controls Inside Dynamically Created Docks
 
-When implementing a dynamic personalized Portal site using the techniques described in [Dynamically Creating RadDock Controls]({%slug dock/how-to/creating-raddock-dynamically%}), the dynamically created controls often contain specialized custom controls. When re-creating the **RadDock** controls after a postback, the application needs to re-create these custom controls as well. The following example shows one way to accomplish this.
-
-1. Create a new AJAX-enabled Web application.
-
-1. In order to add some custom controls to your application, locate the **"Live Demos\Dock\Examples"** folder under your installation directory and drag the **"Default"** folder from there to your solution in the Solution Explorer. Delete the "Default.html", "DefaultCS.aspx", and "DefaultVB.aspx" files. The Solution Explorer should looks something like the following screen shot:
-
-	![](images/dock-adddefaultfolder.png)
+The following example demonstrates how to dynamically create RadDock controls and add controls inside them.
 
 1. To let the user select a control to add to the page, drag a **DropDownList** from the toolbox onto your page. Click on the ellipsis button next to its **Items** property, and add five items, setting the following properties:
 
@@ -30,7 +24,7 @@ When implementing a dynamic personalized Portal site using the techniques descri
 
 	1. **Text**="Weather.ascx", **Value**="~/Default/Weather.ascx"
 
-1. Drag a **Button** from the toolbox onto the page, and set its **Text** property to "Add Dock";
+1. Drag a **Button** from the toolbox onto the page, and set its **Text** property to "Add Dock".
 
 1. Add a **RadDockLayout** with a few **RadDockZone** controls inside it.
 
@@ -38,195 +32,188 @@ When implementing a dynamic personalized Portal site using the techniques descri
 
 	1. At the top of the code behind for your Web page, add two new **using** statements (C#) or **Imports** statements (VB) for System.Collections.Generic and Telerik.Web.UI:
 
-		**C#**
-			 
-			using System.Collections.Generic;
-			using Telerik.Web.UI; 
+		```C#
+		using System.Collections.Generic;
+		using Telerik.Web.UI;
+		```
 
-		**VB**
-		
-			Imports System.Collections.Generic
-			Imports Telerik.Web.UI 
+		```VB
+		Imports System.Collections.Generic
+		Imports Telerik.Web.UI
+		```
 
 	1. Add the following property definition to the class definition of your Web page:
 
-		**C#**
-			 
-			 //Store the info about the added docks in the session.
-			 private List<DockState> CurrentDockStates
-			 {
-			   get
-			   {
-				 List<DockState> _currentDockStates = (List<DockState>)Session["CurrentDockStates"];
-				 if (Object.Equals(_currentDockStates, null))
-				 {
-				   _currentDockStates = new List<DockState>();
-				   Session["CurrentDockStates"] = _currentDockStates;
-				 }
-				 return _currentDockStates;
-			   }
-			   set
-			   {
-				 Session["CurrentDockStates"] = value;
-			   }
-			 }
-					
+		```C#
+		//Store the info about the added docks in the session.
+		private List<DockState> CurrentDockStates
+		{
+		  get
+		  {
+			List<DockState> _currentDockStates = (List<DockState>)Session["CurrentDockStates"];
+			if (Object.Equals(_currentDockStates, null))
+			{
+			  _currentDockStates = new List<DockState>();
+			  Session["CurrentDockStates"] = _currentDockStates;
+			}
+			return _currentDockStates;
+		  }
+		  set
+		  {
+			Session["CurrentDockStates"] = value;
+		  }
+		}
+		```
 
-		**VB**
-		
-			'Store the info about the added docks in the session.
-			Private Property CurrentDockStates() As List(Of DockState)
-				Get
-					Dim _currentDockStates As List(Of DockState) = _
-					  DirectCast(Session("CurrentDockStates"), List(Of DockState))
-					If [Object].Equals(_currentDockStates, Nothing) Then
-						_currentDockStates = New List(Of DockState)()
-						Session("CurrentDockStates") = _currentDockStates
-					End If
-					Return _currentDockStates
-				End Get
-				Set(ByVal value As List(Of DockState))
-					Session("CurrentDockStates") = value
-				End Set
-			End Property
+		```VB
+		' Store the info about the added docks in the session.
+		Private Property CurrentDockStates() As List(Of DockState)
+			Get
+				Dim _currentDockStates As List(Of DockState) = _
+				  DirectCast(Session("CurrentDockStates"), List(Of DockState))
+				If [Object].Equals(_currentDockStates, Nothing) Then
+					_currentDockStates = New List(Of DockState)()
+					Session("CurrentDockStates") = _currentDockStates
+				End If
+				Return _currentDockStates
+			End Get
+			Set(ByVal value As List(Of DockState))
+				Session("CurrentDockStates") = value
+			End Set
+		End Property
+		```
 
 1. Add a **Click** event handler to the Button on the Web page. This event handler creates a new **RadDock** control, creates a custom control inside it, and adds it to the first **RadDockZone** control. Note that the **Tag** property is used to store the information needed to create the custom control:
 
-	**C#**
-	     
-		private RadDock CreateRadDock()
-		{
-		 int docksCount = CurrentDockStates.Count;
-		 RadDock dock = new RadDock();
-		 dock.ID = string.Format("RadDock{0}", docksCount);
-		 dock.Title = string.Format("Dock {0}", docksCount);
-		 dock.UniqueName = Guid.NewGuid().ToString();
-		 dock.Width = Unit.Pixel(300);
-		 return dock;
-		}
-		protected void Button1_Click(object sender, EventArgs e)
-		{
-		  RadDock dock = CreateRadDock();
-		  dock.Tag = DropDownList1.SelectedValue;
-		  LoadWidget(dock);
-		  RadDockZone1.Controls.Add(dock);
-		}
-		
-		private void LoadWidget(RadDock dock)
-		{
-		  if (string.IsNullOrEmpty(dock.Tag))
-		   return;
-		  Control widget = LoadControl(dock.Tag);
-		  dock.ContentContainer.Controls.Add(widget);
-		} 
-				
+	```C#
+	private RadDock CreateRadDock()
+	{
+	 int docksCount = CurrentDockStates.Count;
+	 RadDock dock = new RadDock();
+	 dock.ID = string.Format("RadDock{0}", docksCount);
+	 dock.Title = string.Format("Dock {0}", docksCount);
+	 dock.UniqueName = Guid.NewGuid().ToString();
+	 dock.Width = Unit.Pixel(300);
+	 return dock;
+	}
+	protected void Button1_Click(object sender, EventArgs e)
+	{
+	  RadDock dock = CreateRadDock();
+	  dock.Tag = DropDownList1.SelectedValue;
+	  LoadWidget(dock);
+	  RadDockZone1.Controls.Add(dock);
+	}
 
-	**VB**	
-	
-		Private Function CreateRadDock() As RadDock
-		    Dim docksCount As Integer = CurrentDockStates.Count
-		    Dim dock As New RadDock()
-		    dock.ID = String.Format("RadDock{0}", docksCount)
-		    dock.Title = String.Format("Dock {0}", docksCount)
-		    dock.UniqueName = Guid.NewGuid().ToString()
-		    dock.Width = Unit.Pixel(300)
-		    Return dock
-		End Function
-		Protected Sub Button1_Click(ByVal sender As Object, ByVal e As EventArgs) Handles Button1.Click
-		    Dim dock As RadDock = CreateRadDock()
-		    dock.Tag = DropDownList1.SelectedValue
-		    LoadWidget(dock)
-		    RadDockZone1.Controls.Add(dock)
-		End Sub
-		Private Sub LoadWidget(ByVal dock As RadDock)
-		    If String.IsNullOrEmpty(dock.Tag) Then
-		        Return
-		    End If
-		    Dim widget As Control = LoadControl(dock.Tag)
-		    dock.ContentContainer.Controls.Add(widget)
-		End Sub
+	private void LoadWidget(RadDock dock)
+	{
+	  if (string.IsNullOrEmpty(dock.Tag))
+	   return;
+	  Control widget = LoadControl(dock.Tag);
+	  dock.ContentContainer.Controls.Add(widget);
+	}
+	```
 
-
+	```VB
+	Private Function CreateRadDock() As RadDock
+	    Dim docksCount As Integer = CurrentDockStates.Count
+	    Dim dock As New RadDock()
+	    dock.ID = String.Format("RadDock{0}", docksCount)
+	    dock.Title = String.Format("Dock {0}", docksCount)
+	    dock.UniqueName = Guid.NewGuid().ToString()
+	    dock.Width = Unit.Pixel(300)
+	    Return dock
+	End Function
+	Protected Sub Button1_Click(ByVal sender As Object, ByVal e As EventArgs) Handles Button1.Click
+	    Dim dock As RadDock = CreateRadDock()
+	    dock.Tag = DropDownList1.SelectedValue
+	    LoadWidget(dock)
+	    RadDockZone1.Controls.Add(dock)
+	End Sub
+	Private Sub LoadWidget(ByVal dock As RadDock)
+	    If String.IsNullOrEmpty(dock.Tag) Then
+	        Return
+	    End If
+	    Dim widget As Control = LoadControl(dock.Tag)
+	    dock.ContentContainer.Controls.Add(widget)
+	End Sub
+	```
 
 1. Add code to save and load the state of dynamically created controls when a postback occurs.
 
 	1. Add a **SaveDockLayout** event handler to the **RadDockLayout** component. This event handler calls the **RadDockLayout.GetRegisteredDocksState** method to obtain the current list of dock states and saves the list to the **CurrentDockStates** property.
 
-		**C#**     
-		
-			protected void RadDockLayout1_SaveDockLayout(object sender, DockLayoutEventArgs e)
-			{
-			 CurrentDockStates = RadDockLayout1.GetRegisteredDocksState();
-			} 
+		```C#
+		protected void RadDockLayout1_SaveDockLayout(object sender, DockLayoutEventArgs e)
+		{
+		 CurrentDockStates = RadDockLayout1.GetRegisteredDocksState();
+		}
+		```
 
-		**VB**
-		
-			Protected Sub RadDockLayout1_SaveDockLayout( _
-						  ByVal sender As Object, _
-						  ByVal e As DockLayoutEventArgs) _
-						  Handles RadDockLayout1.SaveDockLayout
-				CurrentDockStates = RadDockLayout1.GetRegisteredDocksState()
-			End Sub
+		```VB
+		Protected Sub RadDockLayout1_SaveDockLayout( _
+				  ByVal sender As Object, _
+				  ByVal e As DockLayoutEventArgs) _
+				  Handles RadDockLayout1.SaveDockLayout
+			CurrentDockStates = RadDockLayout1.GetRegisteredDocksState()
+		End Sub
+		```
 
 	1. Add a **Page_Init** event handler that recreates the **RadDock** controls (including their child custom controls) after a postback:
 
-		**C#**
-			 
-			protected void Page_Init(object sender, EventArgs e)
-			{
-			 for (int i = 0; i < CurrentDockStates.Count; i++)
-			 {
-			   RadDock dock = new RadDock();
-			   dock.ID = string.Format("RadDock{0}", i);
-			   dock.ApplyState(CurrentDockStates[i]);
-			   RadDockLayout1.Controls.Add(dock);
-			   LoadWidget(dock);
-			 }
-			} 
-					
+		```C#
+		protected void Page_Init(object sender, EventArgs e)
+		{
+		 for (int i = 0; i < CurrentDockStates.Count; i++)
+		 {
+		   RadDock dock = new RadDock();
+		   dock.ID = string.Format("RadDock{0}", i);
+		   dock.ApplyState(CurrentDockStates[i]);
+		   RadDockLayout1.Controls.Add(dock);
+		   LoadWidget(dock);
+		 }
+		}
+		```
 
-		**VB**
-		
-			Protected Sub Page_Init(ByVal sender As Object, ByVal e As EventArgs) Handles Me.Init
-				Dim i As Integer
-				For i = 0 To CurrentDockStates.Count - 1
-					Dim dock As RadDock = New RadDock()
-					dock.ID = String.Format("RadDock{0}", i)
-					dock.ApplyState(CurrentDockStates(i))
-					RadDockLayout1.Controls.Add(dock)
-					LoadWidget(dock)
-				Next i
-			End Sub
+		```VB
+		Protected Sub Page_Init(ByVal sender As Object, ByVal e As EventArgs) Handles Me.Init
+			Dim i As Integer
+			For i = 0 To CurrentDockStates.Count - 1
+				Dim dock As RadDock = New RadDock()
+				dock.ID = String.Format("RadDock{0}", i)
+				dock.ApplyState(CurrentDockStates(i))
+				RadDockLayout1.Controls.Add(dock)
+				LoadWidget(dock)
+			Next i
+		End Sub
+		```
 
 	1. Add a **LoadDockLayout** event handler so that the **RadDockLayout** can restore the layout:
 
-		**C#**
-				 
-			protected void RadDockLayout1_LoadDockLayout(object sender, DockLayoutEventArgs e)
-			{
-			 foreach (DockState state in CurrentDockStates)
-			 {
-			   e.Positions[state.UniqueName] = state.DockZoneID;
-			   e.Indices[state.UniqueName] = state.Index;
-			 }
-			} 
-					
+		```C#
+		protected void RadDockLayout1_LoadDockLayout(object sender, DockLayoutEventArgs e)
+		{
+		 foreach (DockState state in CurrentDockStates)
+		 {
+		   e.Positions[state.UniqueName] = state.DockZoneID;
+		   e.Indices[state.UniqueName] = state.Index;
+		 }
+		}
+		```
 
-		**VB**
-		
-			Protected Sub RadDockLayout1_LoadDockLayout( _
-							ByVal sender As Object, _
-							ByVal e As DockLayoutEventArgs) _
-							Handles RadDockLayout1.LoadDockLayout
-				For Each state As DockState In CurrentDockStates
-					e.Positions(state.UniqueName) = state.DockZoneID
-					e.Indices(state.UniqueName) = state.Index
-				Next state
-			End Sub
+		```VB
+		Protected Sub RadDockLayout1_LoadDockLayout( _
+				  ByVal sender As Object, _
+				  ByVal e As DockLayoutEventArgs) _
+				  Handles RadDockLayout1.LoadDockLayout
+			For Each state As DockState In CurrentDockStates
+				e.Positions(state.UniqueName) = state.DockZoneID
+				e.Indices(state.UniqueName) = state.Index
+			Next state
+		End Sub
+		```
 
 >tip To improve performance, you may want to use a hidden update panel for saving state when minimizing, moving and closing docks. This way the docks state is saved faster as there is no need to update the docking zones. See [My Portal](https://demos.telerik.com/aspnet-ajax/Dock/Examples/MyPortal/DefaultCS.aspx) for a live example that uses this technique.
 >
-
 
 # See Also
 

--- a/controls/dock/how-to/creating-raddock-dynamically.md
+++ b/controls/dock/how-to/creating-raddock-dynamically.md
@@ -28,20 +28,20 @@ The following example demonstrates how to dynamically create RadDock controls on
 
 1. Create a new ASP.NET AJAX-enabled Web Site. Add a **Button**, **RadDockLayout**, and a few **RadDockZone** controls inside the **RadDockLayout**:
 
-	**ASP.NET**
-
-		<form id="form2" runat="server">
-		<asp:ScriptManager ID="ScriptManager1" runat="server" />
-		<div>
-		    <asp:Button ID="Button1" runat="server" Text="Add Dock" />
-		    <telerik:RadDockLayout id="RadDockLayout1" runat="server">
-		        <telerik:RadDockZone ID="RadDockZone1" runat="server"  Width="200px" MinHeight="200px" Style="float:left;margin-right:20px;">
-		        </telerik:RadDockZone>
-		        <telerik:RadDockZone ID="RadDockZone2" runat="server" Width="200px" MinHeight="200px" Style="float:left">
-		        </telerik:RadDockZone>
-		    </telerik:RadDockLayout>
-		</div>
-		</form>
+	```ASP.NET
+	<form id="form2" runat="server">
+	<asp:ScriptManager ID="ScriptManager1" runat="server" />
+	<div>
+	    <asp:Button ID="Button1" runat="server" Text="Add Dock" />
+	    <telerik:RadDockLayout id="RadDockLayout1" runat="server">
+	        <telerik:RadDockZone ID="RadDockZone1" runat="server"  Width="200px" MinHeight="200px" Style="float:left;margin-right:20px;">
+	        </telerik:RadDockZone>
+	        <telerik:RadDockZone ID="RadDockZone2" runat="server" Width="200px" MinHeight="200px" Style="float:left">
+	        </telerik:RadDockZone>
+	    </telerik:RadDockLayout>
+	</div>
+	</form>
+	```
 
 	![](images/dock-dynamicdocks1.png)
 
@@ -49,98 +49,98 @@ The following example demonstrates how to dynamically create RadDock controls on
 
 	1. At the top of the code behind for your Web page, add two new **using** statements (C#) or **Imports** statements (VB) for System.Collections.Generic and Telerik.Web.UI:
 
-		**C#**
-		
-			using System.Collections.Generic;
-			using Telerik.Web.UI; 
+		```C#
+		using System.Collections.Generic;
+		using Telerik.Web.UI;
+		```
 
-		**VB**
-		
-			Imports System.Collections.Generic
-			Imports Telerik.Web.UI 
+		```VB
+		Imports System.Collections.Generic
+		Imports Telerik.Web.UI
+		```
 	
 	1. Add the following property definition to the class definition of your Web page:
 
-		**C#**
-			 
-			private List<DockState> CurrentDockStates
+		```C#
+		private List<DockState> CurrentDockStates
+		{
+		 //Store the info about the added docks in the session.
+		 private List<DockState> CurrentDockStates
+		 {
+		   get
+		   {
+			List<DockState> _currentDockStates = (List<DockState>)Session["CurrentDockStates"];
+			if (Object.Equals(_currentDockStates, null))
 			{
-			 //Store the info about the added docks in the session.
-			 private List<DockState> CurrentDockStates
-			 {
-			   get
-			   {
-				 List<DockState> _currentDockStates = (List<DockState>)Session["CurrentDockStates"];
-				 if (Object.Equals(_currentDockStates, null))
-				 {
-				   _currentDockStates = new List<DockState>();
-				   Session["CurrentDockStates"] = _currentDockStates;
-				 }
-				 return _currentDockStates;
-			   }
-			   set
-			   {
-				 Session["CurrentDockStates"] = value;
-			   }
-			 }
-			} 
+			  _currentDockStates = new List<DockState>();
+			  Session["CurrentDockStates"] = _currentDockStates;
+			}
+			return _currentDockStates;
+		   }
+		   set
+		   {
+			Session["CurrentDockStates"] = value;
+		   }
+		 }
+		}
+		```
 
-		**VB**
-		
-			Private Property CurrentDockStates() As List(Of DockState)
-				Get
-					Dim _currentDockStates As List(Of DockState) = _
-					  DirectCast(Session("CurrentDockStates"), List(Of DockState))
-					If [Object].Equals(_currentDockStates, Nothing) Then
-						_currentDockStates = New List(Of DockState)()
-						Session("CurrentDockStates") = _currentDockStates
-					End If
-					Return _currentDockStates
-				End Get
-				Set(ByVal value As List(Of DockState))
-					Session("CurrentDockStates") = value
-				End Set
-			End Property
+		```VB
+		Private Property CurrentDockStates() As List(Of DockState)
+			Get
+				Dim _currentDockStates As List(Of DockState) = _
+				  DirectCast(Session("CurrentDockStates"), List(Of DockState))
+				If [Object].Equals(_currentDockStates, Nothing) Then
+					_currentDockStates = New List(Of DockState)()
+					Session("CurrentDockStates") = _currentDockStates
+				End If
+				Return _currentDockStates
+			End Get
+			Set(ByVal value As List(Of DockState))
+				Session("CurrentDockStates") = value
+			End Set
+		End Property
+		```
 
 1. Add a **Click** event handler to the Button on the Web page. This event handler creates a new **RadDock** control and adds it to the first **RadDockZone** control. Note that when creating a new **RadDock** control, it must have a **UniqueName** so that the **RadDockLayout** component can distinguish it and accurately manage its state:
 
-	**C#**
-	     
-		private RadDock CreateRadDock()
-		{
-		 int docksCount = CurrentDockStates.Count;
-		 RadDock dock = new RadDock();
-		 dock.ID = string.Format("RadDock{0}", docksCount);
-		 dock.Title = string.Format("Dock {0}", docksCount);
-		 dock.Text = string.Format("Added at {0}", DateTime.Now);
-		 dock.UniqueName = Guid.NewGuid().ToString();
-		 dock.Width = Unit.Pixel(300);
-		 return dock;
-		}
-		protected void Button1_Click(object sender, EventArgs e)
-		{
-		 RadDock dock = CreateRadDock();
-		 RadDockLayout1.Controls.Add(dock);
-		 dock.Dock(RadDockZone1);
-		} 
+	```C#
+	private RadDock CreateRadDock()
+	{
+	 int docksCount = CurrentDockStates.Count;
+	 RadDock dock = new RadDock();
+	 dock.ID = string.Format("RadDock{0}", docksCount);
+	 dock.Title = string.Format("Dock {0}", docksCount);
+	 dock.Text = string.Format("Added at {0}", DateTime.Now);
+	 dock.UniqueName = Guid.NewGuid().ToString();
+	 dock.Width = Unit.Pixel(300);
+	 return dock;
+	}
+	protected void Button1_Click(object sender, EventArgs e)
+	{
+	 RadDock dock = CreateRadDock();
+	 RadDockLayout1.Controls.Add(dock);
+	 dock.Dock(RadDockZone1);
+	}
+	```
 
-	**VB**
-	
-	    Private Function CreateRadDock() As RadDock
-	        Dim docksCount As Integer = CurrentDockStates.Count
-	        Dim dock As New RadDock()
-	        dock.ID = String.Format("RadDock{0}", docksCount)
-	        dock.Title = String.Format("Dock {0}", docksCount)
-	        dock.Text = String.Format("Added at {0}", DateTime.Now)
-	        dock.UniqueName = Guid.NewGuid().ToString()
-	        dock.Width = Unit.Pixel(300)
-	        Return dock
-	    End Function
-	    Protected Sub Button1_Click(ByVal sender As Object, ByVal e As EventArgs) Handles Button1.Click
-	        Dim dock As RadDock = CreateRadDock()
-	        RadDockLayout1.Controls.Add(dock)
-	        dock.Dock(RadDockZone1)
-	    End Sub
+	```VB
+	Private Function CreateRadDock() As RadDock
+	    Dim docksCount As Integer = CurrentDockStates.Count
+	    Dim dock As New RadDock()
+	    dock.ID = String.Format("RadDock{0}", docksCount)
+	    dock.Title = String.Format("Dock {0}", docksCount)
+	    dock.Text = String.Format("Added at {0}", DateTime.Now)
+	    dock.UniqueName = Guid.NewGuid().ToString()
+	    dock.Width = Unit.Pixel(300)
+	    Return dock
+	End Function
+	Protected Sub Button1_Click(ByVal sender As Object, ByVal e As EventArgs) Handles Button1.Click
+	    Dim dock As RadDock = CreateRadDock()
+	    RadDockLayout1.Controls.Add(dock)
+	    dock.Dock(RadDockZone1)
+	End Sub
+	```
 	
 	>tip If you want the dynamically created **RadDock** controls to store additional information, you can use the **Tag** property to save that information. For an example that uses this technique, see [Adding Controls Inside Dynamically Created Docks]({%slug dock/how-to/adding-controls-inside-dynamically-created-docks%}).
 
@@ -150,75 +150,75 @@ The following example demonstrates how to dynamically create RadDock controls on
 
 	1. Add a **SaveDockLayout** event handler to the **RadDockLayout** component. This event handler calls the **RadDockLayout.GetRegisteredDocksState** method to obtain the current list of dock states and saves the list to the **CurrentDockStates** property.
 
-		**C#**     
-			
-			protected void RadDockLayout1_SaveDockLayout(object sender, DockLayoutEventArgs e)
-			{
-				CurrentDockStates = RadDockLayout1.GetRegisteredDocksState();
-			} 
+		```C#
+		protected void RadDockLayout1_SaveDockLayout(object sender, DockLayoutEventArgs e)
+		{
+			CurrentDockStates = RadDockLayout1.GetRegisteredDocksState();
+		}
+		```
 					
-		**VB**
-		
-			Protected Sub RadDockLayout1_SaveDockLayout( _
-						  ByVal sender As Object, _
-						  ByVal e As DockLayoutEventArgs) _
-						  Handles RadDockLayout1.SaveDockLayout
-				CurrentDockStates = RadDockLayout1.GetRegisteredDocksState()
-			End Sub
+		```VB
+		Protected Sub RadDockLayout1_SaveDockLayout( _
+				  ByVal sender As Object, _
+				  ByVal e As DockLayoutEventArgs) _
+				  Handles RadDockLayout1.SaveDockLayout
+			CurrentDockStates = RadDockLayout1.GetRegisteredDocksState()
+		End Sub
+		```
 
 	1. Add a **Page_Init** event handler to your Web page that recreates the **RadDock** controls after a postback. It uses the **CurrentDockStates** property (which was set in the **SaveDockLayout** event handler) to initialize their properties using the **RadDock.ApplyState** method. This event handler does not need to add the **RadDock** controls to their parent dock zones, it is enough that they are added to the **RadDockLayout** or one of its children. The **RadDockLayout** control will restore the parent dock zones and position after the **LoadDockLayout** event.
 
-		**C#**
-			 
-			protected void Page_Init(object sender, EventArgs e)
-			{
-			 for (int i = 0; i < CurrentDockStates.Count; i++)
-			 {
-			   RadDock dock = new RadDock();
-			   dock.ID = string.Format("RadDock{0}", i);
-			   dock.ApplyState(CurrentDockStates[i]);
-			   RadDockLayout1.Controls.Add(dock);
-			 }
-			} 
+		```C#
+		protected void Page_Init(object sender, EventArgs e)
+		{
+		 for (int i = 0; i < CurrentDockStates.Count; i++)
+		 {
+		   RadDock dock = new RadDock();
+		   dock.ID = string.Format("RadDock{0}", i);
+		   dock.ApplyState(CurrentDockStates[i]);
+		   RadDockLayout1.Controls.Add(dock);
+		 }
+		}
+		```
 
-		**VB**
-		
-			Protected Sub Page_Init(ByVal sender As Object, ByVal e As EventArgs) Handles Me.Init
-				Dim i As Integer
-				For i = 0 To CurrentDockStates.Count - 1
-					Dim dock As RadDock = New RadDock()
-					dock.ID = String.Format("RadDock{0}", i)
-					dock.ApplyState(CurrentDockStates(i))
-					RadDockLayout1.Controls.Add(dock)
-				Next i
-			End Sub
+		```VB
+		Protected Sub Page_Init(ByVal sender As Object, ByVal e As EventArgs) Handles Me.Init
+			Dim i As Integer
+			For i = 0 To CurrentDockStates.Count - 1
+				Dim dock As RadDock = New RadDock()
+				dock.ID = String.Format("RadDock{0}", i)
+				dock.ApplyState(CurrentDockStates(i))
+				RadDockLayout1.Controls.Add(dock)
+			Next i
+		End Sub
+		```
 
 		>note When the **RadDock** controls are recreated on **Page_Init** , it is important that you always set the same value in their property **ID** . This way you will ensure that the layout of the **RadDock** controls will be persisted after a postback.
 
 	1. Add a **LoadDockLayout** event handler. This event handler tells the **RadDockLayout** control the parent dock zones and indices of the **RadDock** controls that were added in the **Page_Init** event handler. **RadDockLayout** uses this information to restore the layout:
 
-		**C#**
-				 
-			protected void RadDockLayout1_LoadDockLayout(object sender, DockLayoutEventArgs e)
-			{
-			 foreach (DockState state in CurrentDockStates)
-			 {
-			   e.Positions[state.UniqueName] = state.DockZoneID;
-			   e.Indices[state.UniqueName] = state.Index;
-			 }
-			} 
+		```C#
+		protected void RadDockLayout1_LoadDockLayout(object sender, DockLayoutEventArgs e)
+		{
+		 foreach (DockState state in CurrentDockStates)
+		 {
+		   e.Positions[state.UniqueName] = state.DockZoneID;
+		   e.Indices[state.UniqueName] = state.Index;
+		 }
+		}
+		```
 
-		**VB**
-		
-			Protected Sub RadDockLayout1_LoadDockLayout( _
-							ByVal sender As Object, _
-							ByVal e As DockLayoutEventArgs) _
-							Handles RadDockLayout1.LoadDockLayout
-				For Each state As DockState In CurrentDockStates
-					e.Positions(state.UniqueName) = state.DockZoneID
-					e.Indices(state.UniqueName) = state.Index
-				Next state
-			End Sub
+		```VB
+		Protected Sub RadDockLayout1_LoadDockLayout( _
+					  ByVal sender As Object, _
+					  ByVal e As DockLayoutEventArgs) _
+					  Handles RadDockLayout1.LoadDockLayout
+			For Each state As DockState In CurrentDockStates
+				e.Positions(state.UniqueName) = state.DockZoneID
+				e.Indices(state.UniqueName) = state.Index
+			Next state
+		End Sub
+		```
 
 # See Also
 

--- a/controls/editor/appearance-and-styling/create-a-custom-skin.md
+++ b/controls/editor/appearance-and-styling/create-a-custom-skin.md
@@ -44,18 +44,18 @@ In order to explain better the CSS classes of RadEditor, we will use both Editor
 
 1. Put a new server declaration of RadEditor on your page, and set **Skin="MyCustomSkin"** and **EnableEmbeddedSkins="false"**:
 
-	**ASP.NET**
-	
-		<telerik:RadEditor RenderMode="Lightweight" runat="server" Skin="MyCustomSkin" EnableEmbeddedSkins="false" ID="RadEditor1">
-		</telerik:RadEditor>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" runat="server" Skin="MyCustomSkin" EnableEmbeddedSkins="false" ID="RadEditor1">
+	</telerik:RadEditor>
+	```
 
 1. Register Editor.css and Editor.MyCustomSkin.css in the `<head>...</head>` section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 
-	**ASP.NET**
-	
-		<link rel="stylesheet" type="text/css" href="Skins/MyCustomSkin/Editor.MyCustomSkin.css"></link>
-		<%-- The Window skin file is recomeded to be imprted when the built-in dialogs are used --%>
-		<link rel="stylesheet" type="text/css" href="Skins/MyCustomSkin/Window.MyCustomSkin.css"></link>
+	```ASP.NET
+	<link rel="stylesheet" type="text/css" href="Skins/MyCustomSkin/Editor.MyCustomSkin.css"></link>
+	<%-- The Window skin file is recomeded to be imprted when the built-in dialogs are used --%>
+	<link rel="stylesheet" type="text/css" href="Skins/MyCustomSkin/Window.MyCustomSkin.css"></link>
+	```
 
 	Make sure the path to the files is correct, otherwise the skin will not apply.
 

--- a/controls/editor/functionality/dialogs/custom-dialogs.md
+++ b/controls/editor/functionality/dialogs/custom-dialogs.md
@@ -14,157 +14,157 @@ RadEditor provides a flexible mechanism for adding custom dialogs that plug dire
 
 1. Add a custom button that will open the dialog:
 
-	**ASP.NET**
-
-		<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1">
-			<Tools>
-				<telerik:EditorToolGroup>
-					<telerik:EditorTool Name="InsertSpecialLink" Text="Insert Special Link" />
-				</telerik:EditorToolGroup>
-			</Tools>
-			<Content>        
-				Sample Content   
-			</Content>
-		</telerik:RadEditor>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1">
+		<Tools>
+			<telerik:EditorToolGroup>
+				<telerik:EditorTool Name="InsertSpecialLink" Text="Insert Special Link" />
+			</telerik:EditorToolGroup>
+		</Tools>
+		<Content>        
+			Sample Content   
+		</Content>
+	</telerik:RadEditor>
+	```
 
 1. To display your own icon for the InsertSpecialLink button set the following style tag in your page:
 
-	**ASP.NET**
+	```ASP.NET
+	<style type="text/css">
+	/* Styles for Classic rendering */
+	.reToolbar.Default .InsertSpecialLink{
+	    background-image: url(https://demos.telerik.com/aspnet-ajax/editor/examples/customtools/Icons/custom.gif);
+	}
 	
-		<style type="text/css">
-		/* Styles for Classic rendering */
-		.reToolbar.Default .InsertSpecialLink{
-		    background-image: url(https://demos.telerik.com/aspnet-ajax/editor/examples/customtools/Icons/custom.gif);
-		}
-		
-		/* Styles for Lightweight rendering */
-		.reToolBar .reTool.reInsertSpecialLink {
-		    background-image: url(https://demos.telerik.com/aspnet-ajax/editor/examples/customtools/Icons/custom.gif);
-		    background-repeat: no-repeat;
-		}
-		
-		    .reToolBar .reTool.reInsertSpecialLink:before {
-		        display:none;
-		    }
-		</style>
+	/* Styles for Lightweight rendering */
+	.reToolBar .reTool.reInsertSpecialLink {
+	    background-image: url(https://demos.telerik.com/aspnet-ajax/editor/examples/customtools/Icons/custom.gif);
+	    background-repeat: no-repeat;
+	}
+	
+	    .reToolBar .reTool.reInsertSpecialLink:before {
+	        display:none;
+	    }
+	</style>
+	```
 
 1. Add the following JavaScript command under the editor's declaration:
 
-	**JavaScript**
-	    
-		<script type="text/javascript">
-	        Telerik.Web.UI.Editor.CommandList["InsertSpecialLink"] = function (commandName, editor, args)
-	        {   
-	            var elem = editor.getSelectedElement(); //returns the selected element.            
-	            if (elem.tagName == "A")   
-	            {        
-	                editor.selectElement(elem);        
-	                argument = elem;   
-	            }   
-	            else   
-	            {      
-	                var content = editor.getSelectionHtml();      
-	                var link = editor.get_document().createElement("A");      
-	                link.innerHTML = content;               
-	                argument = link;
-	            }     
-	
-	            var myCallbackFunction = function(sender, args)   
-	            {       
-	                editor.pasteHtml(String.format("<a href={0} target='{1}' class='{2}'>{3}</a> ", args.href, args.target, args.className, args.name))
-	            }
-	
-	            editor.showExternalDialog(
-	                'InsertLink.aspx',
-	                argument,
-	                270,
-	                300,
-	                myCallbackFunction,
-	                null,
-	                'Insert Link',
-	                true,
-	                Telerik.Web.UI.WindowBehaviors.Close + Telerik.Web.UI.WindowBehaviors.Move,
-	                false,
-	                false);
-	        };
-	    </script>
+	```JavaScript
+	<script type="text/javascript">
+        Telerik.Web.UI.Editor.CommandList["InsertSpecialLink"] = function (commandName, editor, args)
+        {   
+            var elem = editor.getSelectedElement(); //returns the selected element.            
+            if (elem.tagName == "A")   
+            {        
+                editor.selectElement(elem);        
+                argument = elem;   
+            }   
+            else   
+            {      
+                var content = editor.getSelectionHtml();      
+                var link = editor.get_document().createElement("A");      
+                link.innerHTML = content;               
+                argument = link;
+            }     
+
+            var myCallbackFunction = function(sender, args)   
+            {       
+                editor.pasteHtml(String.format("<a href={0} target='{1}' class='{2}'>{3}</a> ", args.href, args.target, args.className, args.name))
+            }
+
+            editor.showExternalDialog(
+                'InsertLink.aspx',
+                argument,
+                270,
+                300,
+                myCallbackFunction,
+                null,
+                'Insert Link',
+                true,
+                Telerik.Web.UI.WindowBehaviors.Close + Telerik.Web.UI.WindowBehaviors.Move,
+                false,
+                false);
+        };
+    </script>
+	```
 
 	The custom command functions are to open a specified custom dialog and to supply arguments from the main page to the opened dialog by firing the showExternalDialog method. The editor's showExternalDialog() method has the following arguments: **showExternalDialog(_url (aspx/html file), argument, width, height, callbackFunction, callbackArgs, title, modal, behaviors, showStatusbar, showTitlebar_)**;
 
 1. The next step is to create the dialog aspx file. For this scenario, you should create a page named InsertLink.aspx. Once the dialog file is created add the following JavaScript code in it as well as the code for the link insertion:
 
-	**JavaScript**
-	    
-		<fieldset style="width: 214px; height: 192px">
-	        Link name:
-	        <input type="text" id="linkName" /><br />
-	        Link URL:
-	        <input type="text" id="linkUrl" /><br />
-	        Link target:
-	        <input type="text" id="linkTarget" /><br />
-	        Link class:
-	        <input type="text" id="linkClass" /><br />
-	        <input type="button" onclick="javascript:insertLink();" value="Insert Link" />
-	    </fieldset>
-	    
-		<script type="text/javascript">
-	        if (window.attachEvent)
-	        {
-	            window.attachEvent("onload", initDialog);
-	        }
-	        else if (window.addEventListener)
-	        {
-	            window.addEventListener("load", initDialog, false);
-	        }
-	
-	        var linkUrl = document.getElementById("linkUrl");
-	        var linkTarget = document.getElementById("linkTarget");
-	        var linkClass = document.getElementById("linkClass");
-	        var linkName = document.getElementById("linkName");
-	        var workLink = null;
-	
-	        function getRadWindow()
-	        {
-	            if (window.radWindow)
-	            {
-	                return window.radWindow;
-	            }
-	
-	            if (window.frameElement && window.frameElement.radWindow)
-	            {
-	                return window.frameElement.radWindow;
-	            }
-	
-	            return null;
-	        }
-	
-	        function initDialog()
-	        {
-	            var clientParameters = getRadWindow().ClientParameters; //return the arguments supplied from the parent page   
-	                            
-	            linkUrl.value = clientParameters.href;
-	            linkTarget.value = clientParameters.target;
-	            linkClass.value = clientParameters.className;
-	            linkName.value = clientParameters.innerHTML;
-	            workLink = clientParameters;
-	        }
-	        function insertLink() //fires when the Insert Link button is clicked    
-	        {
-	            //create an object and set some custom properties to it            
-	            workLink.href = linkUrl.value;
-	            workLink.target = linkTarget.value;
-	            workLink.className = linkClass.value;
-	            workLink.name = linkName.value;
-	            getRadWindow().close(workLink); //use the close function of the getRadWindow to close the dialog and pass the arguments from the dialog to the callback function on the main page.    
-	        }    
-	    </script>
+	```JavaScript
+	<fieldset style="width: 214px; height: 192px">
+        Link name:
+        <input type="text" id="linkName" /><br />
+        Link URL:
+        <input type="text" id="linkUrl" /><br />
+        Link target:
+        <input type="text" id="linkTarget" /><br />
+        Link class:
+        <input type="text" id="linkClass" /><br />
+        <input type="button" onclick="javascript:insertLink();" value="Insert Link" />
+    </fieldset>
+    
+	<script type="text/javascript">
+        if (window.attachEvent)
+        {
+            window.attachEvent("onload", initDialog);
+        }
+        else if (window.addEventListener)
+        {
+            window.addEventListener("load", initDialog, false);
+        }
+
+        var linkUrl = document.getElementById("linkUrl");
+        var linkTarget = document.getElementById("linkTarget");
+        var linkClass = document.getElementById("linkClass");
+        var linkName = document.getElementById("linkName");
+        var workLink = null;
+
+        function getRadWindow()
+        {
+            if (window.radWindow)
+            {
+                return window.radWindow;
+            }
+
+            if (window.frameElement && window.frameElement.radWindow)
+            {
+                return window.frameElement.radWindow;
+            }
+
+            return null;
+        }
+
+        function initDialog()
+        {
+            var clientParameters = getRadWindow().ClientParameters; //return the arguments supplied from the parent page   
+                            
+            linkUrl.value = clientParameters.href;
+            linkTarget.value = clientParameters.target;
+            linkClass.value = clientParameters.className;
+            linkName.value = clientParameters.innerHTML;
+            workLink = clientParameters;
+        }
+        function insertLink() //fires when the Insert Link button is clicked    
+        {
+            //create an object and set some custom properties to it            
+            workLink.href = linkUrl.value;
+            workLink.target = linkTarget.value;
+            workLink.className = linkClass.value;
+            workLink.name = linkName.value;
+            getRadWindow().close(workLink); //use the close function of the getRadWindow to close the dialog and pass the arguments from the dialog to the callback function on the main page.    
+        }    
+	</script>
+	```
 
 
 1. When the getRadWindow().close(closeArguments) is fired it will pass the closeArguments value to the myCallbackFunction function on the main page. Thus you will be able to construct an HTML link and paste it in the editor with the pasteHtml function:
 
-	**JavaScript**
-	
-	    var myCallbackFunction = function(sender, args){ editor.pasteHtml(String.format("<a href='{0}' target='{1}' class='{2}'>{3}</a> ", args.href, args.target, args.className, args.name)) }
+	```JavaScript
+    var myCallbackFunction = function(sender, args){ editor.pasteHtml(String.format("<a href='{0}' target='{1}' class='{2}'>{3}</a> ", args.href, args.target, args.className, args.name)) }
+	```
 
 
 

--- a/controls/editor/functionality/dialogs/examples/custom-filebrowsercontentprovider.md
+++ b/controls/editor/functionality/dialogs/examples/custom-filebrowsercontentprovider.md
@@ -26,31 +26,31 @@ The steps to implement a custom **FileBrowserContentProvider** are:
 
 1. Set the dialog's property *[ContentProviderTypeName](https://www.telerik.com/help/aspnet-ajax/p_telerik_web_ui_filemanagerdialogconfiguration_contentprovidertypename.html)* e.g. *RadEditor1.ImageManager.ContentProviderTypeName* = "**DatabaseFileBrowser, EditorWebApp"** where the value of the property [ContentProviderTypeName](https://www.telerik.com/help/aspnet-ajax/p_telerik_web_ui_filemanagerdialogconfiguration_contentprovidertypename.html) should be the qualified assembly name of your custom content provider. The general format of the assembly name should be **"Full.Class.Name.Including.The.Namespace, Assembly.Name"**. For example if your content provider class is in a separate project and is declared like this:
 
-	**C#**
-
-		using Telerik.Web.UI.Widgets;
-		
-		namespace RadEditorCustomProvider
-		{
-			public class MyContentProvider : FileBrowserContentProvider  
-			{    
-				//...override base methods  
-			}
-		}
-				
-	**VB**
+	```C#
+	using Telerik.Web.UI.Widgets;
 	
-		Imports Telerik.Web.UI.Widgets
-		
-		Namespace RadEditorCustomProvider
-		
-		
-				Public Class MyContentProvider
-					Inherits FileBrowserContentProvider
-					' ...override base methods 
-				End Class
-		
-		End Namespace
+	namespace RadEditorCustomProvider
+	{
+		public class MyContentProvider : FileBrowserContentProvider  
+		{    
+			//...override base methods  
+		}
+	}
+	```
+	
+	```VB
+	Imports Telerik.Web.UI.Widgets
+	
+	Namespace RadEditorCustomProvider
+	
+	
+			Public Class MyContentProvider
+				Inherits FileBrowserContentProvider
+				' ...override base methods 
+			End Class
+	
+	End Namespace
+	```
 	
 
 ...when it is compiled in the **ContentProviders.dll** assembly, you should set the following value:
@@ -105,25 +105,25 @@ To get started implementing FileBrowserContentProvider:
 
 1. Add a constructor with the signature shown in the code example below. The constructor provides basic dialog and path information.The "Context" parameter allows you to access the current HTTP state including the HTTP Request object:
 
-	**C#**
-	     
-		public MyFileBrowserContentProvider(HttpContext context, string[] searchPatterns, string[] viewPaths, string[] uploadPaths, string[] deletePaths, string selectedUrl, string selectedItemTag)    
-			:    base(context, searchPatterns, viewPaths, uploadPaths, deletePaths, selectedUrl, selectedItemTag)
-		{
-		}
-				
+	```C#
+	public MyFileBrowserContentProvider(HttpContext context, string[] searchPatterns, string[] viewPaths, string[] uploadPaths, string[] deletePaths, string selectedUrl, string selectedItemTag)    
+		:    base(context, searchPatterns, viewPaths, uploadPaths, deletePaths, selectedUrl, selectedItemTag)
+	{
+	}
+	```
+	
 	in VB.NET:
 
-	**VB**
+	```VB
+	Imports Telerik.Web.UI.Widgets
 
-		Imports Telerik.Web.UI.Widgets
-
-			Public MustInherit Class MyFileBrowserContentProvider
-				Inherits FileBrowserContentProvider
-				Public Sub New(ByVal context As HttpContext, ByVal searchPatterns As String(), ByVal viewPaths As String(), ByVal uploadPaths As String(), ByVal deletePaths As String(), ByVal selectedUrl As String, ByVal selectedItemTag As String)
-					MyBase.New(context, searchPatterns, viewPaths, uploadPaths, deletePaths, selectedUrl, selectedItemTag)
+		Public MustInherit Class MyFileBrowserContentProvider
+			Inherits FileBrowserContentProvider
+			Public Sub New(ByVal context As HttpContext, ByVal searchPatterns As String(), ByVal viewPaths As String(), ByVal uploadPaths As String(), ByVal deletePaths As String(), ByVal selectedUrl As String, ByVal selectedItemTag As String)
+				MyBase.New(context, searchPatterns, viewPaths, uploadPaths, deletePaths, selectedUrl, selectedItemTag)
 			End Sub
 		End Class
+	```
 
 
 From this starting point you can implement the FileBrowserContentProvider methods to suit your particular purpose. See [Custom File Dialogs Content Provider LiveDemo](https://demos.telerik.com/aspnet-ajax/editor/examples/dbfilebrowsercontentprovider/defaultcs.aspx) for a running example.

--- a/controls/editor/functionality/dialogs/examples/upload-large-files-(maxrequestlength).md
+++ b/controls/editor/functionality/dialogs/examples/upload-large-files-(maxrequestlength).md
@@ -16,11 +16,11 @@ Upload files larger than 4096 kilobytes using Telerik RadEditor
 
 1. Set the desired max file size in the editor declaration in the aspx/ascx file:
 
-	**ASP.NET**
-
-		<telerik:RadEditor RenderMode="Lightweight" ID="RadEditor1" runat="server">
-			<ImageManager ViewPaths="~/Images" UploadPaths="~/Images" MaxUploadFileSize="7100000" />
-		</telerik:RadEditor>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" ID="RadEditor1" runat="server">
+		<ImageManager ViewPaths="~/Images" UploadPaths="~/Images" MaxUploadFileSize="7100000" />
+	</telerik:RadEditor>
+	```
 
 2. By default, the maximum size of a file to be uploaded to the server using ASP.NET is around 4MB even if you have set **MaxUploadFileSize** > 4MB, due to security restrictions of the ASP.NET Framework. To set a larger size limit, you should make some changes in either the **web.config** file or in the **machine.config**.
 

--- a/controls/editor/functionality/dialogs/externaldialogspath-property.md
+++ b/controls/editor/functionality/dialogs/externaldialogspath-property.md
@@ -30,16 +30,16 @@ The example below demonstrates how to hide the "New Folder" button in all the di
 1. Set the **ExternalDialogsPath** property to point to the EditorDialogs folder
 1. Open the **FileBrowser.ascx** file, which is in the **EditorDialogs** folder and locate the following control, which represent the FileExplorer:
 
-	**ASP.NET**
-
-		<telerik:RadFileExplorer RenderMode="Lightweight" ID="RadFileExplorer1" Height="450px" Width="400px" TreePaneWidth="150px"
-			runat="Server" EnableOpenFile="false" AllowPaging="true" />
+	```ASP.NET
+	<telerik:RadFileExplorer RenderMode="Lightweight" ID="RadFileExplorer1" Height="450px" Width="400px" TreePaneWidth="150px"
+		runat="Server" EnableOpenFile="false" AllowPaging="true" />
+	```
 
 1. To hide the "New Folder" button set the **EnableCreateNewFolder** property to **false**.
 
-	**ASP.NET**
-	
-		<telerik:RadFileExplorer RenderMode="Lightweight" ID="RadFileExplorer1" Height="450px" Width="400px" TreePaneWidth="150px"
-			EnableCreateNewFolder="false" runat="Server" EnableOpenFile="false" AllowPaging="true" />
+	```ASP.NET
+	<telerik:RadFileExplorer RenderMode="Lightweight" ID="RadFileExplorer1" Height="450px" Width="400px" TreePaneWidth="150px"
+		EnableCreateNewFolder="false" runat="Server" EnableOpenFile="false" AllowPaging="true" />
+	```
 
 1. Save the file and test the editor.

--- a/controls/editor/functionality/modules/disable-or-hide-modules.md
+++ b/controls/editor/functionality/modules/disable-or-hide-modules.md
@@ -14,16 +14,16 @@ There are a couple of ways to hide or remove the RadEditor's modules: inline, vi
 
 1. **Inline** In order to **disable** a specific module inside the RadEditor declaration define the needed modules (built-in or custom) only, or set its **Enabled** property to **false**. To **hide** a specific module set its **Visible** property to **false**, e.g.:
 
-	**ASP.NET**
-	
-		<telerik:RadEditor RenderMode="Lightweight" ID="RadEditor1" runat="server">
-			<Modules>
-				<telerik:EditorModule Name="RadEditorHtmlInspector" Enabled="true" Visible="true" />
-				<telerik:EditorModule Name="RadEditorNodeInspector" Enabled="true" Visible="false" />
-				<telerik:EditorModule Name="RadEditorDomInspector" Enabled="false" />
-				<telerik:EditorModule Name="RadEditorStatistics" Enabled="false" />
-			</Modules>
-		</telerik:RadEditor>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" ID="RadEditor1" runat="server">
+		<Modules>
+			<telerik:EditorModule Name="RadEditorHtmlInspector" Enabled="true" Visible="true" />
+			<telerik:EditorModule Name="RadEditorNodeInspector" Enabled="true" Visible="false" />
+			<telerik:EditorModule Name="RadEditorDomInspector" Enabled="false" />
+			<telerik:EditorModule Name="RadEditorStatistics" Enabled="false" />
+		</Modules>
+	</telerik:RadEditor>
+	```
 
 	The declaration above will disable the DomInpector and Statistics modules and will render the real time HTMLmodule, while the NodeInspector will be hidden but available via ModuleManager tool.
 
@@ -34,15 +34,15 @@ There are a couple of ways to hide or remove the RadEditor's modules: inline, vi
 
 
 
-	**C#**
+	```C#
+	RadEditor1.EnsureToolsFileLoaded(); //ensure that the default (or custom) Toolsfile is loaded
+	RadEditor1.Modules.Remove("RadEditorDomInspector"); //remove a specific module
+	```
 	
-		RadEditor1.EnsureToolsFileLoaded(); //ensure that the default (or custom) Toolsfile is loaded
-		RadEditor1.Modules.Remove("RadEditorDomInspector"); //remove a specific module
-	
-	**VB**
-	
-		RadEditor1.EnsureToolsFileLoaded() 'ensure that the default (or custom) Toolsfile is loaded
-		RadEditor1.Modules.Remove("RadEditorDomInspector") 'remove a specific module
+	```VB
+	RadEditor1.EnsureToolsFileLoaded() 'ensure that the default (or custom) Toolsfile is loaded
+	RadEditor1.Modules.Remove("RadEditorDomInspector") 'remove a specific module
+	```
 
 
 	In order to hide a specific module via the code-behind, get a reference to it using the Modules collection and its index and set the Visible property to false. The indexes of the built-in modules are listed below:
@@ -60,15 +60,15 @@ There are a couple of ways to hide or remove the RadEditor's modules: inline, vi
 
 
 
-	**C#**
-	
-		RadEditor1.EnsureToolsFileLoaded(); //ensure that the default (or custom) Toolsfile is loaded
-		RadEditor1.Modules.Clear();//clear the module collections
+	```C#
+	RadEditor1.EnsureToolsFileLoaded(); //ensure that the default (or custom) Toolsfile is loaded
+	RadEditor1.Modules.Clear();//clear the module collections
+	```
 
-	**VB**
-	
-		RadEditor1.EnsureToolsFileLoaded() 'ensure that the default (or custom) Toolsfile is loaded
-		RadEditor1.Modules.Clear() 'clear the module collections
+	```VB
+	RadEditor1.EnsureToolsFileLoaded() 'ensure that the default (or custom) Toolsfile is loaded
+	RadEditor1.Modules.Clear() 'clear the module collections
+	```
 
 
 	The **Enabled** property set to **false** will disable the respective module. The **Visible** property will hide the module. To make it visible again use the Module Manager splitbutton.

--- a/controls/editor/functionality/spellchecker/overview.md
+++ b/controls/editor/functionality/spellchecker/overview.md
@@ -20,9 +20,9 @@ To enable spell checking in your web application you need to accomplish the foll
 
 1. Manually add the handler in your __web.config__ file (in the __httpHandlers__ section):
 
-	**XML**
-	
-		<add verb="*" validate="false" path="Telerik.Web.UI.SpellCheckHandler.axd" type="Telerik.Web.UI.SpellCheckHandler" />
+	```XML
+	<add verb="*" validate="false" path="Telerik.Web.UI.SpellCheckHandler.axd" type="Telerik.Web.UI.SpellCheckHandler" />
+	```
 	
 
 1. Use the RadEditor's Smart Tag in Visual Studio. Note that the smart tag will appear only if you have the __Telerik.Web.UI.dll__ file in your project's __bin__ folder or in the GAC:
@@ -33,13 +33,13 @@ To enable spell checking in your web application you need to accomplish the foll
 
 1. declaring the property in the RadEditor's declaration:
 
-	**ASP.NET**
-	
-		<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1">
-			<Languages>
-				<telerik:SpellCheckerLanguage Code="fr-FR" Title="French" />
-			</Languages>
-		</telerik:RadEditor>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1">
+		<Languages>
+			<telerik:SpellCheckerLanguage Code="fr-FR" Title="French" />
+		</Languages>
+	</telerik:RadEditor>
+	```
 
 
 1. adding the language in the RadEditor's Languages collection. It is recommended to add the language in Page_Load

--- a/controls/editor/functionality/toolbars/buttons/examples/page-break-button.md
+++ b/controls/editor/functionality/toolbars/buttons/examples/page-break-button.md
@@ -14,33 +14,33 @@ Here are the details on how to implement a print break button on the editor's to
 
 1. Add a custom [**PageBreak**] button to the toolbar:
 
-	**ASP.NET**
-	
-		<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1">
-			<Tools>
-				<telerik:EditorToolGroup>
-					<telerik:EditorTool Name="PageBreak" />
-				</telerik:EditorToolGroup>
-			</Tools>
-		</telerik:RadEditor>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1">
+		<Tools>
+			<telerik:EditorToolGroup>
+				<telerik:EditorTool Name="PageBreak" />
+			</telerik:EditorToolGroup>
+		</Tools>
+	</telerik:RadEditor>
+	```
 
 1. In the aspx/ascx file with the editor add the following JavaScript command under the editor's declaration which will be executed each time when the user presses the [**PageBreak**] button:
 
-	**JavaScript**
-	
-		Telerik.Web.UI.Editor.CommandList["PageBreak"] = function (commandName, editor, args)
-		{
-			editor.pasteHtml("<p STYLE='page-break-before: always'>sample text in the paragraph</p>"); 
-		};
+	```JavaScript
+	Telerik.Web.UI.Editor.CommandList["PageBreak"] = function (commandName, editor, args)
+	{
+		editor.pasteHtml("<p STYLE='page-break-before: always'>sample text in the paragraph</p>"); 
+	};
+	```
 
 1. By executing the command above, the user will insert a special print break tag in the editor. The **PageBreak** command will be rendered as a button on the toolbar. In order to look nice, you should provide a button icon and set the following style in the page:
 
-	**XML**
-
-		<style>
-			.reTool .PageBreak
-			{
-				background-image: url(<ImagePath>);
-			}
-		</style>
+	```XML
+	<style>
+		.reTool .PageBreak
+		{
+			background-image: url(<ImagePath>);
+		}
+	</style>
+	```
 

--- a/controls/editor/functionality/toolbars/docking-zones.md
+++ b/controls/editor/functionality/toolbars/docking-zones.md
@@ -41,41 +41,41 @@ Here are a few examples of setting a custom toolbar position:
 
 * In the RadEditor declaration:
 
-	**ASP.NET**
-
-		<telerik:RadEditor RenderMode="Lightweight" ID="RadEditor1" runat="server">
-		    <Tools>
-		        <telerik:EditorToolGroup DockingZone="Left">
-		            <telerik:EditorTool Name="AjaxSpellCheck" />
-		            . . . .
-		        </telerik:EditorToolGroup>
-		    </Tools>
-		</telerik:RadEditor>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" ID="RadEditor1" runat="server">
+	    <Tools>
+	        <telerik:EditorToolGroup DockingZone="Left">
+	            <telerik:EditorTool Name="AjaxSpellCheck" />
+	            . . . .
+	        </telerik:EditorToolGroup>
+	    </Tools>
+	</telerik:RadEditor>
+	```
 
 * In the ToolsFile:
 
-	**XML**
-
-		<tools enabled="true" DockingZone="Bottom">
-		    <tool name="Bold" />
-		    . . . .
-		</tools>
+	```XML
+	<tools enabled="true" DockingZone="Bottom">
+	    <tool name="Bold" />
+	    . . . .
+	</tools>
+	```
 
 * In the code behind:
 
-	**C#**
+	```C#
+	EditorToolGroup toolgroupLeft = new EditorToolGroup(); 
+	toolgroupLeft.Attributes["DockingZone"] = "Left"; 
+	editor.Tools.Add(toolgroupLeft); 
+	toolgroupLeft.Tools.Add(new EditorTool("Bold"));
+	```
 
-		EditorToolGroup toolgroupLeft = new EditorToolGroup(); 
-		toolgroupLeft.Attributes["DockingZone"] = "Left"; 
-		editor.Tools.Add(toolgroupLeft); 
-		toolgroupLeft.Tools.Add(new EditorTool("Bold"));
-
-	**VB**
-
-		Dim toolgroupLeft As New EditorToolGroup()
-		toolgroupLeft.Attributes("DockingZone") = "Left"
-		editor.Tools.Add(toolgroupLeft)
-		toolgroupLeft.Tools.Add(New EditorTool("Bold"))
+	```VB
+	Dim toolgroupLeft As New EditorToolGroup()
+	toolgroupLeft.Attributes("DockingZone") = "Left"
+	editor.Tools.Add(toolgroupLeft)
+	toolgroupLeft.Tools.Add(New EditorTool("Bold"))
+	```
 
 
 >note When enabling only one [Edit Mode]({%slug editor/functionality/editor-views-and-modes/edit-modes%}) (e.g., `EditModes="Design"`) the bottom docking zone will not render. 

--- a/controls/editor/functionality/toolbars/dropdowns/custom-dropdown.md
+++ b/controls/editor/functionality/toolbars/dropdowns/custom-dropdown.md
@@ -14,26 +14,26 @@ Follow the steps below to create custom dropdown in-line in the editor's declara
 
 1. Register the dropdown by adding the telerik:EditorDropDown tag to Tools inner tag of the RadEditor declaration:
 
-	**ASP.NET**
-	
-		<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1" OnClientCommandExecuting="OnClientCommandExecuting">
-			<Tools>
-				<telerik:EditorToolGroup>
-					<telerik:EditorDropDown Name="Emoticons" Text="Emoticons" ItemsPerRow="3" PopupWidth="90"
-						PopupHeight="90">
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil1.gif' />" Value="./Emoticons/smil1.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil2.gif' />" Value="./Emoticons/smil2.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil3.gif' />" Value="./Emoticons/smil3.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil4.gif' />" Value="./Emoticons/smil4.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil8.gif' />" Value="./Emoticons/smil8.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil6.gif' />" Value="./Emoticons/smil6.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil7.gif' />" Value="./Emoticons/smil7.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil9.gif' />" Value="./Emoticons/smil9.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil11.gif' />" Value="./Emoticons/smil11.gif" />
-					</telerik:EditorDropDown>
-				</telerik:EditorToolGroup>
-			</Tools>
-		</telerik:RadEditor>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1" OnClientCommandExecuting="OnClientCommandExecuting">
+		<Tools>
+			<telerik:EditorToolGroup>
+				<telerik:EditorDropDown Name="Emoticons" Text="Emoticons" ItemsPerRow="3" PopupWidth="90"
+					PopupHeight="90">
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil1.gif' />" Value="./Emoticons/smil1.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil2.gif' />" Value="./Emoticons/smil2.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil3.gif' />" Value="./Emoticons/smil3.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil4.gif' />" Value="./Emoticons/smil4.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil8.gif' />" Value="./Emoticons/smil8.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil6.gif' />" Value="./Emoticons/smil6.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil7.gif' />" Value="./Emoticons/smil7.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil9.gif' />" Value="./Emoticons/smil9.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil11.gif' />" Value="./Emoticons/smil11.gif" />
+				</telerik:EditorDropDown>
+			</telerik:EditorToolGroup>
+		</Tools>
+	</telerik:RadEditor>
+	```
 
 	To populate the items of the dropdown use the telerik:EditorDropDownItem inner tag of telerik:EditorDropDown. The **Name** attribute of the telerik:EditorDropDownItem tag represents the item name that will be rendered in the dropdown and the **Value** represents the value of the selected item.
 
@@ -41,101 +41,101 @@ Follow the steps below to create custom dropdown in-line in the editor's declara
 
 	To display an image for an **EditorDropDownItem**, include an HTML `img` element in its **Name** attribute. The `src` can be an application-relative, relative, or absolute URL, and the **Value** can contain the image URL that your client-side command handler inserts into the editor. For example:
 
-	**ASP.NET**
-
-		<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil1.gif' alt='Smile' />" Value="./Emoticons/smil1.gif" />
+	```ASP.NET
+	<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil1.gif' alt='Smile' />" Value="./Emoticons/smil1.gif" />
+	```
 
 1. To create and configure a custom dropdown dynamically on the server use the code below:
 
-	**C#**
-	
-		//add a new Toolbar dynamically    
-		EditorToolGroup dynamicToolbar = new EditorToolGroup();
-		RadEditor1.Tools.Add(dynamicToolbar);
+	```C#
+	//add a new Toolbar dynamically    
+	EditorToolGroup dynamicToolbar = new EditorToolGroup();
+	RadEditor1.Tools.Add(dynamicToolbar);
 
-		//add a custom dropdown and set its items and dimension attributes    
-		EditorDropDown ddn = new EditorDropDown("DynamicDropdown");
-		ddn.Text = "Dynamic dropdown";
+	//add a custom dropdown and set its items and dimension attributes    
+	EditorDropDown ddn = new EditorDropDown("DynamicDropdown");
+	ddn.Text = "Dynamic dropdown";
 
-		//Set the popup width and height    
-		ddn.Attributes["width"] = "110px";
-		ddn.Attributes["popupwidth"] = "240px";
-		ddn.Attributes["popupheight"] = "100px";
+	//Set the popup width and height    
+	ddn.Attributes["width"] = "110px";
+	ddn.Attributes["popupwidth"] = "240px";
+	ddn.Attributes["popupheight"] = "100px";
 
-		//Add items    
-		ddn.Items.Add("Daily signature", "TTYL,<br/>Tom");
-		ddn.Items.Add("Informal Signature", "Greetings,<br/>Tom");
-		ddn.Items.Add("Official Signature", "Yours truly,<br/>Tom Jones");
+	//Add items    
+	ddn.Items.Add("Daily signature", "TTYL,<br/>Tom");
+	ddn.Items.Add("Informal Signature", "Greetings,<br/>Tom");
+	ddn.Items.Add("Official Signature", "Yours truly,<br/>Tom Jones");
 
-		//Add tool to toolbar    
-		dynamicToolbar.Tools.Add(ddn);
+	//Add tool to toolbar    
+	dynamicToolbar.Tools.Add(ddn);
+	```
 
-	**VB**
-		
-		'add a new Toolbar dynamically   
-		Dim dynamicToolbar As New EditorToolGroup()
-		RadEditor1.Tools.Add(dynamicToolbar)
+	```VB
+	'add a new Toolbar dynamically   
+	Dim dynamicToolbar As New EditorToolGroup()
+	RadEditor1.Tools.Add(dynamicToolbar)
 
-		'add a custom dropdown and set its items and dimension attributes   
-		Dim ddn As New EditorDropDown("DynamicDropdown")
-		ddn.Text = "Dynamic dropdown"
+	'add a custom dropdown and set its items and dimension attributes   
+	Dim ddn As New EditorDropDown("DynamicDropdown")
+	ddn.Text = "Dynamic dropdown"
 
-		'Set the popup width and height   
-		ddn.Attributes("width") = "110px"
-		ddn.Attributes("popupwidth") = "240px"
-		ddn.Attributes("popupheight") = "100px"
+	'Set the popup width and height   
+	ddn.Attributes["width"] = "110px"
+	ddn.Attributes["popupwidth"] = "240px"
+	ddn.Attributes["popupheight"] = "100px"
 
-		'Add items   
-		ddn.Items.Add("Daily signature", "TTYL,<br/>Tom")
-		ddn.Items.Add("Informal Signature", "Greetings,<br/>Tom")
-		ddn.Items.Add("Official Signature", "Yours truly,<br/>Tom Jones")
+	'Add items   
+	ddn.Items.Add("Daily signature", "TTYL,<br/>Tom")
+	ddn.Items.Add("Informal Signature", "Greetings,<br/>Tom")
+	ddn.Items.Add("Official Signature", "Yours truly,<br/>Tom Jones")
 
-		'Add tool to toolbar   
-		dynamicToolbar.Tools.Add(ddn)
+	'Add tool to toolbar   
+	dynamicToolbar.Tools.Add(ddn)
+	```
 
 1. After adding the custom dropdown to the editor's toolbar, you should attach a function to the editor's OnClientCommandExecuting, the arguments of which will give you reference to the selected dropdown name and value.Once you obtain the selected item's value, you can modify it and paste it through the pasteHtml function in the content area, e.g.
 
-	**ASP.NET**
-		
-		<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1" OnClientCommandExecuting="OnClientCommandExecuting">
-			<Tools>
-				<telerik:EditorToolGroup>
-					<telerik:EditorDropDown Name="Emoticons" Text="Emoticons" ItemsPerRow="3" PopupWidth="90"
-						PopupHeight="90">
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil1.gif' />" Value="./Emoticons/smil1.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil2.gif' />" Value="./Emoticons/smil2.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil3.gif' />" Value="./Emoticons/smil3.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil4.gif' />" Value="./Emoticons/smil4.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil8.gif' />" Value="./Emoticons/smil8.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil6.gif' />" Value="./Emoticons/smil6.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil7.gif' />" Value="./Emoticons/smil7.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil9.gif' />" Value="./Emoticons/smil9.gif" />
-						<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil11.gif' />" Value="./Emoticons/smil11.gif" />
-					</telerik:EditorDropDown>
-				</telerik:EditorToolGroup>
-			</Tools>
-		</telerik:RadEditor>
-		<script type="text/javascript">
-			function OnClientCommandExecuting(editor, args)
-			{    
-				var name = args.get_name();    
-				var val = args.get_value();    
-				
-				if (name == "Emoticons")    
-				{        
-					editor.pasteHtml("<img src='" + val + "'>");               
-					//Cancel the further execution of the command as such a command does not exist in the editor command list        
-					args.set_cancel(true);    
-				}       
-				
-				if (name == "DynamicDropdown")    
-				{        
-					editor.pasteHtml("<div style='width:100px;background-color:#fafafa;border:1px dashed #aaaaaa;'>" + val + "</div>");
-					//Cancel the further execution of the command as such a command does not exist in the editor command list        
-					args.set_cancel(true);
-				}
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1" OnClientCommandExecuting="OnClientCommandExecuting">
+		<Tools>
+			<telerik:EditorToolGroup>
+				<telerik:EditorDropDown Name="Emoticons" Text="Emoticons" ItemsPerRow="3" PopupWidth="90"
+					PopupHeight="90">
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil1.gif' />" Value="./Emoticons/smil1.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil2.gif' />" Value="./Emoticons/smil2.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil3.gif' />" Value="./Emoticons/smil3.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil4.gif' />" Value="./Emoticons/smil4.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil8.gif' />" Value="./Emoticons/smil8.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil6.gif' />" Value="./Emoticons/smil6.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil7.gif' />" Value="./Emoticons/smil7.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil9.gif' />" Value="./Emoticons/smil9.gif" />
+					<telerik:EditorDropDownItem Name="<img src='./Emoticons/smil11.gif' />" Value="./Emoticons/smil11.gif" />
+				</telerik:EditorDropDown>
+			</telerik:EditorToolGroup>
+		</Tools>
+	</telerik:RadEditor>
+	<script type="text/javascript">
+		function OnClientCommandExecuting(editor, args)
+		{    
+			var name = args.get_name();    
+			var val = args.get_value();    
+			
+			if (name == "Emoticons")    
+			{        
+				editor.pasteHtml("<img src='" + val + "'>");               
+				//Cancel the further execution of the command as such a command does not exist in the editor command list        
+				args.set_cancel(true);    
+			}       
+			
+			if (name == "DynamicDropdown")    
+			{        
+				editor.pasteHtml("<div style='width:100px;background-color:#fafafa;border:1px dashed #aaaaaa;'>" + val + "</div>");
+				//Cancel the further execution of the command as such a command does not exist in the editor command list        
+				args.set_cancel(true);
 			}
-		</script>
+		}
+	</script>
+	```
 
 
 ## See Also

--- a/controls/editor/functionality/track-changes-and-comments/track-changes.md
+++ b/controls/editor/functionality/track-changes-and-comments/track-changes.md
@@ -52,10 +52,10 @@ The following steps will guide you on enabling the **Track Changes** feature and
 
 1. Set the **EnableTrackChanges** property to **true**:
 
-	**ASP.NET**
-	
-		<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1" EnableTrackChanges="true">
-		</telerik:RadEditor>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1" EnableTrackChanges="true">
+	</telerik:RadEditor>
+	```
 	
 
 1. Enable the built-in **Track Changes** tools:

--- a/controls/editor/how-to/edit-template-in-grid.md
+++ b/controls/editor/how-to/edit-template-in-grid.md
@@ -78,88 +78,88 @@ In a new AJAX Enabled Web Application:
 1. In the code-behind, create helper methods to connect to the Email table and populate the grid:
 
 
-	**C#**
+	```C#
+	// Returns a connection to the Access Database
+	private OleDbConnection CreateConnection()
+	{
+		OleDbConnection connection = new OleDbConnection();
+		connection.ConnectionString =
+				"Provider=Microsoft.Jet.OLEDB.4.0;Data Source=" +
+				Request.MapPath("\\App_Data\\email.mdb") + ";User ID=;Password=;";
+		connection.Open();
+		return connection;
+	}
+	// Populates the grid with all columns and rows of the "Email" table.
+	private void ReadAllRecords()
+	{
+		OleDbConnection connection = CreateConnection();
+		OleDbCommand command2 = new OleDbCommand("SELECT * FROM email", connection);
+		MyDataGrid.DataSource = command2.ExecuteReader();
+		MyDataGrid.DataBind();
+		connection.Close();
+	} 	
 	
-		// Returns a connection to the Access Database
-		private OleDbConnection CreateConnection()
-		{
-			OleDbConnection connection = new OleDbConnection();
-			connection.ConnectionString =
-					"Provider=Microsoft.Jet.OLEDB.4.0;Data Source=" +
-					Request.MapPath("\\App_Data\\email.mdb") + ";User ID=;Password=;";
-			connection.Open();
-			return connection;
-		}
-		// Populates the grid with all columns and rows of the "Email" table.
-		private void ReadAllRecords()
-		{
-			OleDbConnection connection = CreateConnection();
-			OleDbCommand command2 = new OleDbCommand("SELECT * FROM email", connection);
-			MyDataGrid.DataSource = command2.ExecuteReader();
-			MyDataGrid.DataBind();
-			connection.Close();
-		} 	
-		
-	**VB**
+	```
 	
-		' Returns a connection to the Access Database
-		Private Function CreateConnection() As OleDbConnection
-			Dim connection As New OleDbConnection()
-			connection.ConnectionString = "Provider=Microsoft.Jet.OLEDB.4.0;Data Source=" + Request.MapPath("\App_Data\email.mdb") + ";User ID=;Password=;"
-			connection.Open()
-			Return connection
-		End Function
-		' Populates the grid with all columns and rows of the "Email" table.
-		Private Sub ReadAllRecords()
-			Dim connection As OleDbConnection = CreateConnection()
-			Dim command2 As New OleDbCommand("SELECT * FROM email", connection)
-			MyDataGrid.DataSource = command2.ExecuteReader()
-			MyDataGrid.DataBind()
-			connection.Close()
-		End Sub
+	```VB
+	' Returns a connection to the Access Database
+	Private Function CreateConnection() As OleDbConnection
+		Dim connection As New OleDbConnection()
+		connection.ConnectionString = "Provider=Microsoft.Jet.OLEDB.4.0;Data Source=" + Request.MapPath("\App_Data\email.mdb") + ";User ID=;Password=;"
+		connection.Open()
+		Return connection
+	End Function
+	' Populates the grid with all columns and rows of the "Email" table.
+	Private Sub ReadAllRecords()
+		Dim connection As OleDbConnection = CreateConnection()
+		Dim command2 As New OleDbCommand("SELECT * FROM email", connection)
+		MyDataGrid.DataSource = command2.ExecuteReader()
+		MyDataGrid.DataBind()
+		connection.Close()
+	End Sub
+	```
 
 
 1. Create event handlers for the grid Update, Edit and Cancel events. Also handle the Page_Load event to initially populate the grid. Replace the event handler code with the example below:
 
 
 
-	**C#**
-	
-		protected void Page_Load(object sender, EventArgs e)
+	```C#
+	protected void Page_Load(object sender, EventArgs e)
+	{
+		if (!IsPostBack)
 		{
-			if (!IsPostBack)
-			{
-				ReadAllRecords();
-			}
-		}
-		protected void MyDataGrid_Update(object sender, DataGridCommandEventArgs e)
-		{
-			RadEditor radEditor = ((RadEditor)e.Item.FindControl("RadEditor1"));
-			string content = radEditor.Content;
-			string itemID = ((Label)e.Item.FindControl("lblID")).Text;
-			const string updateCommand = "UPDATE Email SET [Date] = Now(), [Body] = @content WHERE [ID] = @nid";
-			OleDbConnection connection = CreateConnection();
-			OleDbCommand command = new OleDbCommand(updateCommand, connection);
-			command.Parameters.AddWithValue("content", content);
-			command.Parameters.AddWithValue("nid", Convert.ToInt32(itemID));
-			command.ExecuteNonQuery();
-			connection.Close();
-			MyDataGrid.EditItemIndex = -1;
 			ReadAllRecords();
 		}
-		protected void MyDataGrid_Edit(object sender, DataGridCommandEventArgs e)
-		{
-			MyDataGrid.EditItemIndex = e.Item.ItemIndex;
-			ReadAllRecords();
-		}
+	}
+	protected void MyDataGrid_Update(object sender, DataGridCommandEventArgs e)
+	{
+		RadEditor radEditor = ((RadEditor)e.Item.FindControl("RadEditor1"));
+		string content = radEditor.Content;
+		string itemID = ((Label)e.Item.FindControl("lblID")).Text;
+		const string updateCommand = "UPDATE Email SET [Date] = Now(), [Body] = @content WHERE [ID] = @nid";
+		OleDbConnection connection = CreateConnection();
+		OleDbCommand command = new OleDbCommand(updateCommand, connection);
+		command.Parameters.AddWithValue("content", content);
+		command.Parameters.AddWithValue("nid", Convert.ToInt32(itemID));
+		command.ExecuteNonQuery();
+		connection.Close();
+		MyDataGrid.EditItemIndex = -1;
+		ReadAllRecords();
+	}
+	protected void MyDataGrid_Edit(object sender, DataGridCommandEventArgs e)
+	{
+		MyDataGrid.EditItemIndex = e.Item.ItemIndex;
+		ReadAllRecords();
+	}
 
-		protected void MyDataGrid_CancelCommand(object source, DataGridCommandEventArgs e)
-		{
-			ReadAllRecords();
-		} 			
+	protected void MyDataGrid_CancelCommand(object source, DataGridCommandEventArgs e)
+	{
+		ReadAllRecords();
+	} 			
+	```
 
-	**VB**
-	
+	```VB
 	    Protected Sub Page_Load(ByVal sender As Object, ByVal e As EventArgs)
 	        If Not IsPostBack Then
 	            ReadAllRecords()
@@ -188,6 +188,7 @@ In a new AJAX Enabled Web Application:
 	    Protected Sub MyDataGrid_CancelCommand(ByVal source As Object, ByVal e As DataGridCommandEventArgs)
 	        ReadAllRecords()
 	    End Sub
+	```
 
 
 ## See Also

--- a/controls/editor/how-to/insert-text-from-a-text-control-at-the-cursor-position.md
+++ b/controls/editor/how-to/insert-text-from-a-text-control-at-the-cursor-position.md
@@ -14,30 +14,30 @@ The example below demonstrates how to insert text at the cursor position in RadE
 
 1. Add a textbox to your page:
 
-	**ASP.NET**
-	
-		<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1">
-		</telerik:RadEditor>
-		<asp:TextBox ID="TextBox1" runat="server" Height="97px"></asp:TextBox>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1">
+	</telerik:RadEditor>
+	<asp:TextBox ID="TextBox1" runat="server" Height="97px"></asp:TextBox>
+	```
 
 1. Add a button to execute the paste command:
 
-	**ASP.NET**
-
-		<input id="Insert" type="button" value="<--Insert" onclick="PasteTextInEditor(Form1.TextBox1.value);" />
+	```ASP.NET
+	<input id="Insert" type="button" value="<--Insert" onclick="PasteTextInEditor(Form1.TextBox1.value);" />
+	```
 
 
 1. Include the **PasteTextInEditor** method in your ascx/aspx file. Use the **pasteHtml** method to paste the content from the textbox:
 
-	**ASP.NET**
-	
-	    <script type="text/javascript">
-	        function PasteTextInEditor(text)
-	        {
-	            var editor = $find("<%=RadEditor1.ClientID%>"); //get a reference to RadEditor client object    
-	            editor.pasteHtml(text); //PasteHtml is a method from the editor client side API
-	        }
-	    </script>
+	```ASP.NET
+	<script type="text/javascript">
+	    function PasteTextInEditor(text)
+	    {
+	        var editor = $find("<%=RadEditor1.ClientID%>"); //get a reference to RadEditor client object    
+	        editor.pasteHtml(text); //PasteHtml is a method from the editor client side API
+	    }
+	</script>
+	```
 
 
 1. Test the solution.

--- a/controls/editor/how-to/obtain-current-editor's-selection-as-html.md
+++ b/controls/editor/how-to/obtain-current-editor's-selection-as-html.md
@@ -18,40 +18,40 @@ The example below shows how to obtain the current selection using a custom butto
 
 1. Add the custom CustomSelectionTool button to the editor toolbar:
 
-	**ASP.NET**
-	
-		<style type="text/css">
-			.reToolbar.Default .CustomSelectionTool
-			{
-				background-image: url(https://www.telerik.com/DEMOS/ASPNET/RadControls/Editor/Skins/Default/buttons/Custom.gif);
-			}
-		</style>
-		...
-		<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1">
-			<Tools>
-				<telerik:EditorToolGroup>
-					<telerik:EditorTool Name="CustomSelectionTool" />
-				</telerik:EditorToolGroup>
-			</Tools>
-			<Content>        
-				sample lowercase content    
-			</Content>
-		</telerik:RadEditor>
+	```ASP.NET
+	<style type="text/css">
+		.reToolbar.Default .CustomSelectionTool
+		{
+			background-image: url(https://www.telerik.com/DEMOS/ASPNET/RadControls/Editor/Skins/Default/buttons/Custom.gif);
+		}
+	</style>
+	...
+	<telerik:RadEditor RenderMode="Lightweight" runat="server" ID="RadEditor1">
+		<Tools>
+			<telerik:EditorToolGroup>
+				<telerik:EditorTool Name="CustomSelectionTool" />
+			</telerik:EditorToolGroup>
+		</Tools>
+		<Content>        
+			sample lowercase content    
+		</Content>
+	</telerik:RadEditor>
+	```
 
 
 1. Add the CustomSelectionTool javascript command under the editor declaration in your aspx / ascx:
 
-	**JavaScript**
-			 
-		Telerik.Web.UI.Editor.CommandList["CustomSelectionTool"] = function(commandName, editor, args)
-		{   
-			// To get the selected Html   
-			var currentSelectedHtml = editor.getSelectionHtml();   
-			// Convert it to upper case   
-			currentSelectedHtml = currentSelectedHtml.toUpperCase();
-			// To insert a Html portion at the current cursor position, you can use:   
-			editor.pasteHtml(currentSelectedHtml);
-		};
+	```JavaScript
+	Telerik.Web.UI.Editor.CommandList["CustomSelectionTool"] = function(commandName, editor, args)
+	{   
+		// To get the selected Html   
+		var currentSelectedHtml = editor.getSelectionHtml();   
+		// Convert it to upper case   
+		currentSelectedHtml = currentSelectedHtml.toUpperCase();
+		// To insert a Html portion at the current cursor position, you can use:   
+		editor.pasteHtml(currentSelectedHtml);
+	};
+	```
 
 
 

--- a/controls/editor/how-to/use-themes.md
+++ b/controls/editor/how-to/use-themes.md
@@ -20,29 +20,29 @@ RadEditor can be configured to use **ASP.NET 2.0 Themes** in the same manner as 
 
 1. Open the skin file and add the RadEditor page directive and declaration. Set the RadEditor **SkinId** property to a unique name. In the example below, SkinId is declared as "SettingProperties".
 
-	**ASP.NET**
-	
-		<%@ register tagprefix="telerik" namespace="Telerik.Web.UI" assembly="Telerik.Web.UI" %>
-		<telerik:radeditor runat="server" SkinId="SettingProperties" Width="500" Height="500">
-			<content>       
-				<b>Setting inline properties</b> 
-			</content>
-		</telerik:radeditor>
+	```ASP.NET
+	<%@ register tagprefix="telerik" namespace="Telerik.Web.UI" assembly="Telerik.Web.UI" %>
+	<telerik:radeditor runat="server" SkinId="SettingProperties" Width="500" Height="500">
+		<content>       
+			<b>Setting inline properties</b> 
+		</content>
+	</telerik:radeditor>
+	```
 
 1. In the ASPX/ASCX where the skin will be used, set the Theme in the page declaration. In the example below, the **Theme** is declared as "Theme1" to match the contents of App_Themes.
 
-	**ASP.NET**
-		
-		<%@ page language="C#" autoeventwireup="true" codebehind="Default.aspx.cs" theme="Theme1"
-			inherits="prometheusRadEditor001._Default" %>
+	```ASP.NET
+	<%@ page language="C#" autoeventwireup="true" codebehind="Default.aspx.cs" theme="Theme1"
+		inherits="prometheusRadEditor001._Default" %>
+	```
 
 
 1. In the RadEditor declaration, set the **SkinId** property to match the skin file created earlier. In the example below, SkinID is set to "SettingProperties" to match the **SkinId** declared in the skin file earlier.
 
-	**ASP.NET**
-	
-		<telerik:RadEditor RenderMode="Lightweight" ID="RadEditor1" SkinID="SettingProperties" runat="server">
-		</telerik:RadEditor>
+	```ASP.NET
+	<telerik:RadEditor RenderMode="Lightweight" ID="RadEditor1" SkinID="SettingProperties" runat="server">
+	</telerik:RadEditor>
+	```
 
 
 >caution The controls form the Telerik® UI for ASP.NET AJAX suite in general and the editor control in specific, have both a **Skin** and **SkinID** Properties. **SkinID** refers to the general theming mechanism introduced in ASP.NET 2.0 and applies to standard ASP.NET controls, such as asp:Button. The **Skin** property refers to the Telerik® UI for ASP.NET AJAX **-** specific theming mechanism and allows you to set a number of CSS styles to a Telerik control at one time.

--- a/controls/editor/managing-content/getting-and-setting-content/save-in-external-file.md
+++ b/controls/editor/managing-content/getting-and-setting-content/save-in-external-file.md
@@ -23,71 +23,71 @@ You can save the RadEditor content in an external text or HTML file as well as l
 
 1. To save the RadEditor content in the external HTML file when the Submit button is pressed, add the following code inside the button click eventhandler in the codebehind:
 
-	**C#**
-	
-		protected string path = "test.html"; //specify the path to your file
-		...
-		protected void Button1_Click1(object sender, EventArgs e)
-		{
-		   //Open file for writing and write content
-		   using (StreamWriter externalFile = new StreamWriter(this.MapPath(path), false))
-		   {
-			   externalFile.Write(RadEditor1.Content);
-		   }
-		} 
+	```C#
+	protected string path = "test.html"; //specify the path to your file
+	...
+	protected void Button1_Click1(object sender, EventArgs e)
+	{
+	   //Open file for writing and write content
+	   using (StreamWriter externalFile = new StreamWriter(this.MapPath(path), false))
+	   {
+		   externalFile.Write(RadEditor1.Content);
+	   }
+	} 
+	```
 
-	**VB**
-		
-		Protected path As String = "test.html"
-		...
-		'specify the path to your file
-		Protected Sub Button1_Click1(ByVal sender As Object, ByVal e As EventArgs)
-			'Open file for writing and write content
-			Using externalFile As New StreamWriter(Me.MapPath(path), False)
-				externalFile.Write(RadEditor1.Content)
-			End Using
-		End Sub
+	```VB
+	Protected path As String = "test.html"
+	...
+	'specify the path to your file
+	Protected Sub Button1_Click1(ByVal sender As Object, ByVal e As EventArgs)
+		'Open file for writing and write content
+		Using externalFile As New StreamWriter(Me.MapPath(path), False)
+			externalFile.Write(RadEditor1.Content)
+		End Using
+	End Sub
+	```
 
 
 
 1. To load the external file content in the RadEditor, read the file content with the ReadFile function and assign the returned string to the Html property of RadEditor in the Page_Load event:
 
-	**C#**
+	```C#
+	protected void Page_Load(object sender, EventArgs e)
+	{
+	   if (!Page.IsPostBack)
+	   {
+		   RadEditor1.Content = ReadFile(Server.MapPath(path));
+	   }
+	}
 	
-		protected void Page_Load(object sender, EventArgs e)
-		{
-		   if (!Page.IsPostBack)
-		   {
-			   RadEditor1.Content = ReadFile(Server.MapPath(path));
-		   }
-		}
-		
-		protected string ReadFile(string path)
-		{
-		   if (!System.IO.File.Exists(path))
-		   {
-			   return string.Empty;
-		   }
-		   using (System.IO.StreamReader sr = new System.IO.StreamReader(path))
-		   {
-			   return sr.ReadToEnd();
-		   }
-		} 
+	protected string ReadFile(string path)
+	{
+	   if (!System.IO.File.Exists(path))
+	   {
+		   return string.Empty;
+	   }
+	   using (System.IO.StreamReader sr = new System.IO.StreamReader(path))
+	   {
+		   return sr.ReadToEnd();
+	   }
+	} 
+	```
 
-	**VB**
-
-		Protected Sub Page_Load(ByVal sender As Object, ByVal e As EventArgs)
-			If Not Page.IsPostBack Then
-				RadEditor1.Content = ReadFile(Server.MapPath(path))
-			End If
-		End Sub
+	```VB
+	Protected Sub Page_Load(ByVal sender As Object, ByVal e As EventArgs)
+		If Not Page.IsPostBack Then
+			RadEditor1.Content = ReadFile(Server.MapPath(path))
+		End If
+	End Sub
 	
-		Protected Function ReadFile(ByVal path As String) As String
-			If Not System.IO.File.Exists(path) Then
-				Return String.Empty
-			End If
-			Using sr As New System.IO.StreamReader(path)
-				Return sr.ReadToEnd()
-			End Using
-		End Function
+	Protected Function ReadFile(ByVal path As String) As String
+		If Not System.IO.File.Exists(path) Then
+			Return String.Empty
+		End If
+		Using sr As New System.IO.StreamReader(path)
+			Return sr.ReadToEnd()
+		End Using
+	End Function
+	```
 

--- a/controls/editor/mobile-support/render-modes.md
+++ b/controls/editor/mobile-support/render-modes.md
@@ -28,27 +28,27 @@ There are two ways to configure the rendering mode of the controls:
 
 * The **RenderMode property** in the markup or in the code-behind that can be used for a particular instance:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadEditor ID="RadEditor1" runat="server" RenderMode="Lightweight">
+	</telerik:RadEditor>
+	```
 
-		<telerik:RadEditor ID="RadEditor1" runat="server" RenderMode="Lightweight">
-		</telerik:RadEditor>
+	```C#
+	RadEditor1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	```
 
-	**C#**
-
-		RadEditor1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-
-	**VB**
-
-		RadEditor1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight	
+	```VB
+	RadEditor1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight	
+	```
 
 
 * A **global setting in the web.config** file that will affect the entire application, unless a concrete value is specified for a given control instance:
 
-	**XML**
-
-		<appSettings>
-			<add key="Telerik.Web.UI.Editor.RenderMode" value="lightweight" />
-		</appSettings>
+	```XML
+	<appSettings>
+		<add key="Telerik.Web.UI.Editor.RenderMode" value="lightweight" />
+	</appSettings>
+	```
 
 
 

--- a/controls/fileexplorer/accessibility-and-internationalization/keyboard-support.md
+++ b/controls/fileexplorer/accessibility-and-internationalization/keyboard-support.md
@@ -92,15 +92,15 @@ A visual indication that the user is currently interacting with one of the FileE
 
 1. Use the following CSS code to set blue border to active controls. Note, that you could use the same selectors to apply your desired style.
 		
-	**CSS**	
-		
-		.rfeFocused:focus,
-		.rfeFocused.RadTreeView:focus,
-		.rfeFocused.RadGrid:focus,
-		.rfeFocused.RadToolBar:focus
-		{ 
-			border: 2px solid Blue !important;
-		} 
+	```CSS
+	.rfeFocused:focus,
+	.rfeFocused.RadTreeView:focus,
+	.rfeFocused.RadGrid:focus,
+	.rfeFocused.RadToolBar:focus
+	{ 
+		border: 2px solid Blue !important;
+	} 
+	```
 
 	![](images/radfileexplorer-focused-element.png)
 

--- a/controls/fileexplorer/getting-started.md
+++ b/controls/fileexplorer/getting-started.md
@@ -42,13 +42,13 @@ In the steps below you will see how to declare a simple **RadFileExplorer** in t
 
 1. The final result should be similar to:
 
-	**ASP.NET**
-	
-	    <telerik:RadScriptManager runat="server"></telerik:RadScriptManager>
-	    
-        <telerik:RadFileExplorer ID="RadFileExplorer1" runat="server" InitialPath="/Files/Private">
-            <Configuration ViewPaths="~/Files" DeletePaths="~/Files/Private" UploadPaths="~/Files" SearchPatterns="*.txt, *.xlsx, *.docx, *.rtf, *.zip"/>
-        </telerik:RadFileExplorer>
+    ```ASP.NET
+    <telerik:RadScriptManager runat="server"></telerik:RadScriptManager>
+
+    <telerik:RadFileExplorer ID="RadFileExplorer1" runat="server" InitialPath="/Files/Private">
+        <Configuration ViewPaths="~/Files" DeletePaths="~/Files/Private" UploadPaths="~/Files" SearchPatterns="*.txt, *.xlsx, *.docx, *.rtf, *.zip"/>
+    </telerik:RadFileExplorer>
+    ```
 
 1. Save the page and run it in the browser.
 

--- a/controls/floatingactionbutton/client-side-programming/overview.md
+++ b/controls/floatingactionbutton/client-side-programming/overview.md
@@ -23,17 +23,17 @@ RadFloatingActionButton is a server-side wrapper over the Kendo UI FloatingActio
 
 * Use the `get_kendoWidget()` method of the MS AJAX wrapper:
 
-    **JavaScript**
-
-        var floatingActionButtonObject  = $find("<%=RadFloatingActionButton1.ClientID %>"); //the standard script control object
-        var kendoFloatingActionButton = floatingActionButtonObject.get_kendoWidget(); //the Kendo widget
+    ```JavaScript
+    var floatingActionButtonObject  = $find("<%=RadFloatingActionButton1.ClientID %>"); //the standard script control object
+    var kendoFloatingActionButton = floatingActionButtonObject.get_kendoWidget(); //the Kendo widget
+    ```
 
 
 * Get the Kendo Widget in its usual way. Make sure to use the `$telerik._kendo.jQuery` reference that has the Kendo widget data:
 
-    **JavaScript**
-    
-        var kendoFloatingActionButton = $telerik._kendo.jQuery("#<%=RadFloatingActionButton1.ClientID %>").data("kendoFloatingActionButton");
+    ```JavaScript
+    var kendoFloatingActionButton = $telerik._kendo.jQuery("#<%=RadFloatingActionButton1.ClientID %>").data("kendoFloatingActionButton");
+    ```
 
 >important As of the 2026 Q1 release, Kendo jQuery widget plugins and data are registered on `$telerik._kendo.jQuery` — a different jQuery instance from `$telerik.$`. If you use `$telerik.$` with `.data("kendoXxx")`, it will return `undefined`. Always use `$telerik._kendo.jQuery` when accessing the underlying Kendo widget via the `.data()` method. The recommended approach, however, is to use the `get_kendoWidget()` method shown above. 
 

--- a/controls/formdecorator/integration-with-radcontrols.md
+++ b/controls/formdecorator/integration-with-radcontrols.md
@@ -75,37 +75,37 @@ To decorate RadInput controls fully, you need to:
 1. set the `CssClass` property of the input to the RadFormDecorator classes depending on the `RenderMode`:
     * for the `Lightweight` RenderMode use `CssClass="rfdTextInput"`
         
-        **ASP.NET**
-
-            <telerik:RadFormDecorator runat="server" ID="RadFormDecorator1" DecoratedControls="All"
-                RenderMode="Lightweight" Skin="Black" />
-            <telerik:RadTextBox runat="server" ID="RadTextBox1" Label="Label for generic textbox"
-                Skin="" RenderMode="Lightweight" CssClass="rfdTextInput">
-            </telerik:RadTextBox>
-            <telerik:RadNumericTextBox runat="server" ID="RadNumericTextBox1" Label="Label for numeric textbox"
-                Skin="" RenderMode="Lightweight" CssClass="rfdTextInput">
-            </telerik:RadNumericTextBox>
-            <telerik:RadMaskedTextBox runat="server" ID="RadMaskedTextBox1" Label="Label for masked textbox"
-                Skin="" RenderMode="Lightweight" CssClass="rfdTextInput"></telerik:RadMaskedTextBox>
-            <telerik:RadDatePicker runat="server" ID="RadDatePicker1"
-                Skin="" RenderMode="Lightweight">
-                <DateInput CssClass="rfdTextInput" Label="Label for date input"></DateInput>
-            </telerik:RadDatePicker>
+        ```ASP.NET
+        <telerik:RadFormDecorator runat="server" ID="RadFormDecorator1" DecoratedControls="All"
+            RenderMode="Lightweight" Skin="Black" />
+        <telerik:RadTextBox runat="server" ID="RadTextBox1" Label="Label for generic textbox"
+            Skin="" RenderMode="Lightweight" CssClass="rfdTextInput">
+        </telerik:RadTextBox>
+        <telerik:RadNumericTextBox runat="server" ID="RadNumericTextBox1" Label="Label for numeric textbox"
+            Skin="" RenderMode="Lightweight" CssClass="rfdTextInput">
+        </telerik:RadNumericTextBox>
+        <telerik:RadMaskedTextBox runat="server" ID="RadMaskedTextBox1" Label="Label for masked textbox"
+            Skin="" RenderMode="Lightweight" CssClass="rfdTextInput"></telerik:RadMaskedTextBox>
+        <telerik:RadDatePicker runat="server" ID="RadDatePicker1"
+            Skin="" RenderMode="Lightweight">
+            <DateInput CssClass="rfdTextInput" Label="Label for date input"></DateInput>
+        </telerik:RadDatePicker>
+        ```
 
     * for the `Classic` RenderMode use `CssClass="rfdRoundedCorners rfdDecorated"`
 
-        **ASP.NET**
-
-            <telerik:RadFormDecorator runat="server" ID="RadFormDecorator1" DecoratedControls="All"
-                RenderMode="Classic" Skin="Black" />
-            <telerik:RadTextBox runat="server" ID="RadTextBox1" Label="Label for generic textbox"
-                Skin="" RenderMode="Classic" CssClass="rfdRoundedCorners rfdDecorated">
-            </telerik:RadTextBox>
-            <telerik:RadNumericTextBox runat="server" ID="RadNumericTextBox1" Label="Label for numeric textbox"
-                Skin="" RenderMode="Classic" CssClass="rfdRoundedCorners rfdDecorated">
-            </telerik:RadNumericTextBox>
-            <telerik:RadMaskedTextBox runat="server" ID="RadMaskedTextBox1" Label="Label for masked textbox"
-                Skin="" RenderMode="Classic" CssClass="rfdRoundedCorners rfdDecorated"></telerik:RadMaskedTextBox>
+        ```ASP.NET
+        <telerik:RadFormDecorator runat="server" ID="RadFormDecorator1" DecoratedControls="All"
+            RenderMode="Classic" Skin="Black" />
+        <telerik:RadTextBox runat="server" ID="RadTextBox1" Label="Label for generic textbox"
+            Skin="" RenderMode="Classic" CssClass="rfdRoundedCorners rfdDecorated">
+        </telerik:RadTextBox>
+        <telerik:RadNumericTextBox runat="server" ID="RadNumericTextBox1" Label="Label for numeric textbox"
+            Skin="" RenderMode="Classic" CssClass="rfdRoundedCorners rfdDecorated">
+        </telerik:RadNumericTextBox>
+        <telerik:RadMaskedTextBox runat="server" ID="RadMaskedTextBox1" Label="Label for masked textbox"
+            Skin="" RenderMode="Classic" CssClass="rfdRoundedCorners rfdDecorated"></telerik:RadMaskedTextBox>
+        ```
             <telerik:RadDatePicker runat="server" ID="RadDatePicker1" Skin="" RenderMode="Classic">
                 <DateInput CssClass="rfdRoundedCorners rfdDecorated" Label="Label for date input"></DateInput>
             </telerik:RadDatePicker>

--- a/controls/formdecorator/mobile-support/render-modes.md
+++ b/controls/formdecorator/mobile-support/render-modes.md
@@ -30,25 +30,24 @@ There are two ways to configure the rendering mode of the controls:
 
 * The property **RenderMode** of RadFormDecorator can be used to set the render mode of a particular instance of the control:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadFormDecorator runat="server" ID="RadFormDecorator1" RenderMode="Lightweight">
+	</telerik:RadFormDecorator>
+	```
 
-		<telerik:RadFormDecorator runat="server" ID="RadFormDecorator1" RenderMode="Lightweight">
-		</telerik:RadFormDecorator>
+	```C#
+	RadFormDecorator1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	```
 
-	**C#**
-
-		RadFormDecorator1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-
-	**VB**
-
-		RadFormDecorator1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
-		
+	```VB
+	RadFormDecorator1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```
 * The render mode for the form decorator control can be specified globally in web.config by adding an app key:
 
-	**XML**
-
-		<appSettings>
-		  <add key="Telerik.Web.UI.FormDecorator.RenderMode" value="lightweight" />
-		</appSettings>
+	```XML
+	<appSettings>
+	  <add key="Telerik.Web.UI.FormDecorator.RenderMode" value="lightweight" />
+	</appSettings>
+	```
 
 

--- a/controls/formdecorator/overview.md
+++ b/controls/formdecorator/overview.md
@@ -61,15 +61,15 @@ To decorate the form elements on a webpage:
 
 1. Register **Telerik.Web.UI** namespace tagprefix:
 
-	**ASP.NET**
-		
-		<%@ Register TagPrefix="telerik" Namespace="Telerik.Web.UI" Assembly="Telerik.Web.UI" %>
+	```ASP.NET
+	<%@ Register TagPrefix="telerik" Namespace="Telerik.Web.UI" Assembly="Telerik.Web.UI" %>
+	```
 
 1. Add the **RadFormDecorator** server tag on the webpage:
 
-	**ASP.NET**
-		
-		<telerik:RadFormdecorator id="FormDecorator1" runat="server" DecoratedControls="all" Skin="Web20"></telerik:RadFormdecorator>
+	```ASP.NET
+	<telerik:RadFormdecorator id="FormDecorator1" runat="server" DecoratedControls="all" Skin="Web20"></telerik:RadFormdecorator>
+	```
 
 
 Values of the **DecoratedControls** property are:

--- a/controls/formdecorator/troubleshooting/checkbox-and-radio-button-click-event-is-not-fired.md
+++ b/controls/formdecorator/troubleshooting/checkbox-and-radio-button-click-event-is-not-fired.md
@@ -36,41 +36,41 @@ There are a few options you can choose from, in order to handle the scenario des
 
 	>caption **Example 1**: Associating a label to an input element by matching the input's "id" to the label's "for" attribute.
 
-	**ASP.NET**
-
-		<telerik:RadFormDecorator RenderMode="Lightweight" ID="RadFormDecorator1" runat="server" DecoratedControls="All" />
-		<input type="checkbox" id="checkbox1" name="name1" value="value1" onclick="alert(1);" /><label for="checkbox1">label 1</label>
-		<input type="radio" id="radio1" name="name2" value="value2" onclick="alert(2);" /><label for="radio1">label 2</label>
+	```ASP.NET
+	<telerik:RadFormDecorator RenderMode="Lightweight" ID="RadFormDecorator1" runat="server" DecoratedControls="All" />
+	<input type="checkbox" id="checkbox1" name="name1" value="value1" onclick="alert(1);" /><label for="checkbox1">label 1</label>
+	<input type="radio" id="radio1" name="name2" value="value2" onclick="alert(2);" /><label for="radio1">label 2</label>
+	```
 
 * Insert a space between the input and the label - either in the markup (see an **Example 2**), or with JavaScript prior to the **RadFormDecorator**'s decoration (see an **Example 3**).
 
 	>caption **Example 2**: Inserting a whitespace between an input and a label element in the markup.
 
-	**ASP.NET**
-
-		<telerik:RadFormDecorator RenderMode="Lightweight" ID="RadFormDecorator1" runat="server" DecoratedControls="All" />
-		<input type="checkbox" name="name1" value="value1" onclick="alert(1);" /> <label>label 1</label>
-		<input type="radio" name="name2" value="value2" onclick="alert(2);" /> <label>label 2</label>
+	```ASP.NET
+	<telerik:RadFormDecorator RenderMode="Lightweight" ID="RadFormDecorator1" runat="server" DecoratedControls="All" />
+	<input type="checkbox" name="name1" value="value1" onclick="alert(1);" /> <label>label 1</label>
+	<input type="radio" name="name2" value="value2" onclick="alert(2);" /> <label>label 2</label>
+	```
 
 	>caption **Example 3**: Inserting a whitespace between an input and a label element with JavaScript prior to decoration.
 
-	**JavaScript**
-
-		<%--The external jQuery reference is needed because RadFormDecorator doesn't reference internally jQuery--%>
-		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-		<script type="text/javascript">
-			$(function () {
-				$("label").each(function () {
-					this.parentNode.insertBefore(document.createTextNode(" "), this);
-				});
+	```JavaScript
+	<%--The external jQuery reference is needed because RadFormDecorator doesn't reference internally jQuery--%>
+	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+	<script type="text/javascript">
+		$(function () {
+			$("label").each(function () {
+				this.parentNode.insertBefore(document.createTextNode(" "), this);
 			});
-		</script>
+		});
+	</script>
+	```
 
-	**ASP.NET**
-
-		<telerik:RadFormDecorator RenderMode="Lightweight" ID="RadFormDecorator1" runat="server" DecoratedControls="All" />
-		<input type="checkbox" name="name1" value="value1" onclick="alert(1);" /><label>label 1</label>
-		<input type="radio" name="name2" value="value2" onclick="alert(2);" /><label>label 2</label>
+	```ASP.NET
+	<telerik:RadFormDecorator RenderMode="Lightweight" ID="RadFormDecorator1" runat="server" DecoratedControls="All" />
+	<input type="checkbox" name="name1" value="value1" onclick="alert(1);" /><label>label 1</label>
+	<input type="radio" name="name2" value="value2" onclick="alert(2);" /><label>label 2</label>
+	```
 
 # See Also
 

--- a/controls/formdecorator/troubleshooting/decorated-gridview-is-not-bound-to-sqldatasource-with-controlparameter.md
+++ b/controls/formdecorator/troubleshooting/decorated-gridview-is-not-bound-to-sqldatasource-with-controlparameter.md
@@ -18,7 +18,7 @@ The asp:GridView cannot be bound on initial page load when it is decorated by Ra
 
 >caption **Example 1**: Decorated asp:GridView is not visible on initial page load when it is bound to the SqlDataSource with ControlParameter.
 
-**ASP.NET**
+```ASP.NET
 
 	<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" DecoratedControls="All" />
 
@@ -40,19 +40,13 @@ The asp:GridView cannot be bound on initial page load when it is decorated by Ra
 				Type="String"></asp:ControlParameter>
 		</SelectParameters>
 	</asp:SqlDataSource>
+```
 
 
-**Cause:**
+	```ASP.NET
+	<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" DecoratedControls="All" />
 
-In order to decorate all of the controls on the page, the RadFormDecorator decorates the children controls of the complex controls as well (i.e., the RadFormDecorator iterates through the controls' collections). 
-
-There is, however, a binding issue with the GridView when the SqlDataSource is used with a ControlParameter and at the same time, the GridView's collection is accessed from the code behind. This issue can be easily reproduced on a page with no Telerik® UI for ASP.NET AJAX controls and is shown in **Example 2**. The problem also affects the scenario with the RadFormDecorator from **Example 1**.
-
->caption **Example 2**: asp:GridView cannot be bound to the SqlDataSource with a ControlParameter when the GridView's collection is accessed from the code behind.
-
-**ASP.NET**
-
-	<asp:DropDownList ID="Dropdownlist1" runat="server" DataSourceID="DropDownListDataSource" AutoPostBack="true" DataTextField="CompanyName" DataValueField="CustomerID">
+	<asp:DropDownList ID="Dropdownlist1" runat="server" AutoPostBack="true" DataTextField="CompanyName" DataValueField="CustomerID">
 	</asp:DropDownList>
 	<asp:SqlDataSource runat="server" ID="DropDownListDataSource" ConnectionString="<%$ ConnectionStrings:NorthwindConnectionString %>"
 		ProviderName="System.Data.SqlClient" SelectCommand="Select [CustomerID], [CompanyName], [Address], [City], [PostalCode], [Country] From [Customers]"
@@ -70,19 +64,29 @@ There is, however, a binding issue with the GridView when the SqlDataSource is u
 				Type="String"></asp:ControlParameter>
 		</SelectParameters>
 	</asp:SqlDataSource>
+	```
+		OldValuesParameterFormatString="original_{0}" ConflictDetection="CompareAllValues">
+		<SelectParameters>
+			<asp:ControlParameter ControlID="Dropdownlist1" Name="CustomerID" PropertyName="SelectedValue"
+				Type="String"></asp:ControlParameter>
+		</SelectParameters>
+	</asp:SqlDataSource>
+```
 
-**C#**
+```C#
 
 	protected void Page_PreRender(object sender, EventArgs e)
 	{
 		var c = GridView1.Controls;
 	}
+	```
 
-**VB**
+	```VB
 
 	Protected Sub Page_PreRender(sender As Object, e As EventArgs)
 		Dim c = GridView1.Controls
 	End Sub
+	```
 
 
 **Solution:**
@@ -93,9 +97,9 @@ There are a few options you can choose from in order to handle the scenario desc
 
 	>caption **Example 3**: Binding DropDownList's data from the code behind instead of declaring its DataSourceID property.
 
-	**ASP.NET**
-
-		<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" DecoratedControls="All" />
+    ```ASP.NET
+	<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" DecoratedControls="All" />
+	```
 
 		<asp:DropDownList ID="Dropdownlist1" runat="server" AutoPostBack="true" DataTextField="CompanyName" DataValueField="CustomerID">
 		</asp:DropDownList>
@@ -116,53 +120,53 @@ There are a few options you can choose from in order to handle the scenario desc
 			</SelectParameters>
 		</asp:SqlDataSource>
 
-	**C#**
+    ```C#
+	protected void Page_Init(object sender, EventArgs e)
+	{
+		DataSourceSelectArguments args = new DataSourceSelectArguments();
+		DataView view = (DataView)DropDownListDataSource.Select(args);
+		DataTable dt = view.ToTable();
 
-		protected void Page_Init(object sender, EventArgs e)
-		{
-			DataSourceSelectArguments args = new DataSourceSelectArguments();
-			DataView view = (DataView)DropDownListDataSource.Select(args);
-			DataTable dt = view.ToTable();
+		Dropdownlist1.DataSource = dt;
+		Dropdownlist1.DataBind();
+	}
+	```
 
-			Dropdownlist1.DataSource = dt;
-			Dropdownlist1.DataBind();
-		}
+    ```VB
+	Protected Sub Page_Init(sender As Object, e As EventArgs)
+		Dim args As New DataSourceSelectArguments()
+		Dim view As DataView = DirectCast(DropDownListDataSource.[Select](args), DataView)
+		Dim dt As DataTable = view.ToTable()
 
-	**VB**
-
-		Protected Sub Page_Init(sender As Object, e As EventArgs)
-			Dim args As New DataSourceSelectArguments()
-			Dim view As DataView = DirectCast(DropDownListDataSource.[Select](args), DataView)
-			Dim dt As DataTable = view.ToTable()
-
-			Dropdownlist1.DataSource = dt
-			Dropdownlist1.DataBind()
-		End Sub
+		Dropdownlist1.DataSource = dt
+		Dropdownlist1.DataBind()
+	End Sub
+	```
 
 * Skip the following controls form decoration - GridFormDetailsViews, LoginControls, Textbox and ValidationSummary:
 
 	>caption **Example 4**: Skip the GridFormDetailsViews, LoginControls, Textbox and ValidationSummary controls from decoration.
 
-	**ASP.NET**
-
-		<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" ControlsToSkip="GridFormDetailsViews,LoginControls,Textbox,ValidationSummary" />
+	```ASP.NET
+	<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" ControlsToSkip="GridFormDetailsViews,LoginControls,Textbox,ValidationSummary" />
+	```
 
 * Set the DataSourceID property of the DropDownList in the Page_Init event. This approach, however, will force the DropDownList to rebind itself, which may lead to performance issues for large data sources.
 
-	**C#**
+	```C#
+	protected void Page_Init(object sender, EventArgs e)
+	{
+		Dropdownlist1.DataSourceID = "DropDownListDataSource";
+		Dropdownlist1.DataBind();
+	}
+	```
 
-		protected void Page_Init(object sender, EventArgs e)
-		{
-			Dropdownlist1.DataSourceID = "DropDownListDataSource";
-			Dropdownlist1.DataBind();
-		}
-
-	**VB**
-
-		Protected Sub Page_Init(sender As Object, e As EventArgs)
-			Dropdownlist1.DataSourceID = "DropDownListDataSource"
-			Dropdownlist1.DataBind()
-		End Sub
+	```VB
+	Protected Sub Page_Init(sender As Object, e As EventArgs)
+		Dropdownlist1.DataSourceID = "DropDownListDataSource"
+		Dropdownlist1.DataBind()
+	End Sub
+	```
 
 
 # See Also

--- a/controls/formdecorator/troubleshooting/input-appearance-is-not-updated-when-disabled-in-internet-explorer.md
+++ b/controls/formdecorator/troubleshooting/input-appearance-is-not-updated-when-disabled-in-internet-explorer.md
@@ -53,46 +53,46 @@ There are two ways to workaround this browser limitation:
 
 	>caption **Example 2**: Skipping checkbox, button and radio button elements from decoration by **RadFormDecorator**.
 
-	**ASP.NET**
-
-		<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" DecoratedControls="All" ControlsToSkip="CheckBoxes,Buttons,RadioButtons" />
+	```ASP.NET
+	<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" DecoratedControls="All" ControlsToSkip="CheckBoxes,Buttons,RadioButtons" />
+	```
 
 * Set the CSS classes **RadFormDecorator** uses for the disabled inputs appearance manually. **RadFormDecorator** will remove them when needed (e.g., if inputs are enabled their appearance will be updated too).
 
 	>caption **Example 3**: Setting the necessary CSS classes to the decorated elements used for their disabled state in Internet Explorer.
 
-	**JavaScript**
+	```JavaScript
+	<script type="text/javascript">
+		function disableInputs() {
 
-		<script type="text/javascript">
-			function disableInputs() {
+			var inputCheckBox = $get("<%=myInputCheckBox2.ClientID%>");
+			var inputRadio = $get("<%=myInputRadio2.ClientID%>");
+			var inputButton = $get("<%=myInputButton2.ClientID%>");
 
-				var inputCheckBox = $get("<%=myInputCheckBox2.ClientID%>");
-				var inputRadio = $get("<%=myInputRadio2.ClientID%>");
-				var inputButton = $get("<%=myInputButton2.ClientID%>");
-
-				//If the browser is IE manually set the css classes for the disabled state of inputs
-				if ($telerik.isIE) {
-					setDisabledCssClassToDecoratedElement(inputCheckBox, 'rfdInputDisabled');
-					setDisabledCssClassToDecoratedElement(inputRadio, 'rfdInputDisabled');
-					setDisabledCssClassToDecoratedElement(inputButton, 'rfdInputDisabled');
-				}
-				inputCheckBox.disabled = true;
-				inputRadio.disabled = true;
-				inputButton.disabled = true;
+			//If the browser is IE manually set the css classes for the disabled state of inputs
+			if ($telerik.isIE) {
+				setDisabledCssClassToDecoratedElement(inputCheckBox, 'rfdInputDisabled');
+				setDisabledCssClassToDecoratedElement(inputRadio, 'rfdInputDisabled');
+				setDisabledCssClassToDecoratedElement(inputButton, 'rfdInputDisabled');
 			}
-			function setDisabledCssClassToDecoratedElement(element, disabledCssClass) {
-				var decoratedElement = Telerik.Web.UI.RadFormDecorator.getDecoratedElement(element);
-				Sys.UI.DomElement.addCssClass(decoratedElement, disabledCssClass);
-			}
-		</script>
+			inputCheckBox.disabled = true;
+			inputRadio.disabled = true;
+			inputButton.disabled = true;
+		}
+		function setDisabledCssClassToDecoratedElement(element, disabledCssClass) {
+			var decoratedElement = Telerik.Web.UI.RadFormDecorator.getDecoratedElement(element);
+			Sys.UI.DomElement.addCssClass(decoratedElement, disabledCssClass);
+		}
+	</script>
+	```
 
-	**ASP.NET**
-
-		<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" DecoratedControls="All" RenderMode="Classic" />
-		<telerik:RadButton ID="RadButton2" runat="server" AutoPostBack="false" OnClientClicked="disableInputs" Text="Disable Inputs" />
-		<input type="checkbox" id="myInputCheckBox2" runat="server" name="name1" value="value1" checked="checked" />
-		<input type="radio" id="myInputRadio2" runat="server" name="name2" value="value2" />
-		<input type="button" id="myInputButton2" runat="server" name="name3" value="value3" />
+	```ASP.NET
+	<telerik:RadFormDecorator ID="RadFormDecorator1" runat="server" DecoratedControls="All" RenderMode="Classic" />
+	<telerik:RadButton ID="RadButton2" runat="server" AutoPostBack="false" OnClientClicked="disableInputs" Text="Disable Inputs" />
+	<input type="checkbox" id="myInputCheckBox2" runat="server" name="name1" value="value1" checked="checked" />
+	<input type="radio" id="myInputRadio2" runat="server" name="name2" value="value2" />
+	<input type="button" id="myInputButton2" runat="server" name="name3" value="value3" />
+	```
 
 # See Also
 

--- a/controls/grid/columns/reordering.md
+++ b/controls/grid/columns/reordering.md
@@ -45,61 +45,56 @@ When columns are created programmatically, they appear in the same order that th
 
 * The **SwapColumns(String,String)** method accepts the **UniqueNames** for two columns to swap:
 
-	**C#**
-		
-		grid.MasterTableView.SwapColumns("City","ContactName");			
-
-	**VB**
-
-		grid.MasterTableView.SwapColumns("City","ContactName")			
-
+	```C#
+	grid.MasterTableView.SwapColumns("City","ContactName");			
+	```
+	```VB
+	grid.MasterTableView.SwapColumns("City","ContactName")			
+	```
 
 * The **SwapColumns(Int32,Int32)** method accepts the indexes of two columns to swap:
-
-	**C#**
-     
-		grid.MasterTableView.SwapColumns(3, 4);				
-
-	**VB**
-
-		grid.MasterTableView.SwapColumns(3, 4)
+	```C#
+	grid.MasterTableView.SwapColumns(3, 4);				
+	```
+	```VB
+	grid.MasterTableView.SwapColumns(3, 4)
+	```
 
 
 * The **OrderIndex** property lets you change the position of columns to move them to a specific location:
 
 	>caution When using the **OrderIndex** property to reorder columns, make sure that you assign values so that no two columns have the same index and no index is omitted.
 
-	**C#**
-
-		GridColumnCollection cols = grid.MasterTableView.Columns;
-		GridColumn c = cols.FindByUniqueNameSafe(columnName);
-		if (c != null){ 
-		    int start = c.OrderIndex; 
-		    for (int i= start; i < cols.Count; i++)  
-		    { 
-		        c = cols[i]; 
-		        if (i < cols.Count - 1)   
-		            c.OrderIndex = i+1;
-		        else     
-		            c.OrderIndex = start;  
-		    }
-		}			
-
-	**VB**
-
-		Dim cols As GridColumnCollection = grid.MasterTableView.Columns
-		Dim c As GridColumn = cols.FindByUniqueNameSafe(columnName)
-		If c IsNot Nothing Then
-		Dim start As Integer = c.OrderIndex
-		    For i As Integer = start To cols.Count - 1
-			    c = cols(i)
-			    If i < cols.Count - 1 Then
-				    c.OrderIndex = i + 1
-			    Else
-				    c.OrderIndex = start
-			    End If
-		    Next
-		End If
+	```C#
+	GridColumnCollection cols = grid.MasterTableView.Columns;
+	GridColumn c = cols.FindByUniqueNameSafe(columnName);
+	if (c != null){ 
+	    int start = c.OrderIndex; 
+	    for (int i= start; i < cols.Count; i++)  
+	    { 
+	        c = cols[i]; 
+	        if (i < cols.Count - 1)   
+	            c.OrderIndex = i+1;
+	        else     
+	            c.OrderIndex = start;  
+	    }
+	}			
+	```
+	```VB
+	Dim cols As GridColumnCollection = grid.MasterTableView.Columns
+	Dim c As GridColumn = cols.FindByUniqueNameSafe(columnName)
+	If c IsNot Nothing Then
+	Dim start As Integer = c.OrderIndex
+	    For i As Integer = start To cols.Count - 1
+		    c = cols(i)
+		    If i < cols.Count - 1 Then
+			    c.OrderIndex = i + 1
+		    Else
+			    c.OrderIndex = start
+		    End If
+	    Next
+	End If
+	```
 
 
 

--- a/controls/grid/data-editing/automatic-datasource-operations.md
+++ b/controls/grid/data-editing/automatic-datasource-operations.md
@@ -167,7 +167,7 @@ Automatic operations through the **DataSource** control are not supported when y
 
 1. Make the user control class (which represents your user control) implement the *IBindableControl* interface as follows:
 
-	**ASP.NET**
+  ```ASP.NET
 
 		<telerik:RadGrid RenderMode="Lightweight" ID="RadGrid1" AllowSorting="true" AllowPaging="true" DataSourceID="SqlDataSource1"
 		  runat="server">
@@ -182,16 +182,18 @@ Automatic operations through the **DataSource** control are not supported when y
 			</Columns>
 		  </MasterTableView>
 		</telerik:RadGrid>
+  ```
 
 
-	**ASP.NET**
+  ```ASP.NET
 
 		<%@ Control Language="C#" AutoEventWireup="true" CodeFile="WebUserControl.ascx.cs" Inherits="WebUserControl" %>
 		  <asp:TextBox ID="TextBox1" Text='<%# Bind("ProductName") %>' runat="server" />
 		  <asp:Button ID="Button1" Text="Update" CommandName="Update" runat="server" />
 		  <asp:Button ID="Button2" Text="Cancel" CommandName="Cancel" runat="server" />
+  ```
 
-	**C#**
+  ```C#
 
 		public partial class WebUserControl : System.Web.UI.UserControl, IBindableControl
 		{
@@ -200,8 +202,9 @@ Automatic operations through the **DataSource** control are not supported when y
 				dictionary["ProductName"] = TextBox1.Text;
 			}
 		}
+  ```
 
-	**VB**
+  ```VB
 
 		Partial Public Class WebUserControl
 			Inherits System.Web.UI.UserControl
@@ -210,6 +213,7 @@ Automatic operations through the **DataSource** control are not supported when y
 				dictionary("ProductName") = TextBox1.Text
 			End Sub
 		End Class
+  ```
 
 
 2. Use a template edit form (**FormTemplate**) instead of a **WebUserControl**. You can copy the template from the user control to the edit form template and modify the binding logic using the **Bind**() syntax (two-way binding) instead of **DataBinder.Eval** (one-way binding). For an example of this approach, see [Form template edit form.](https://demos.telerik.com/aspnet-ajax/Grid/Examples/DataEditing/TemplateFormUpdate/DefaultCS.aspx)

--- a/controls/grid/functionality/exporting/integration-with-telerik-document-processing-library.md
+++ b/controls/grid/functionality/exporting/integration-with-telerik-document-processing-library.md
@@ -109,7 +109,7 @@ docx.RadFlowDocument flowDocument = new docx.RadFlowDocument();
 docx.Section section = flowDocument.Sections.AddSection();
 // Insert a Table into the Document Section
 docx.Table table = section.Blocks.AddTable();
-        
+		
 // Create Cell Border Style
 docx.Styles.TableCellBorders tableCellBorders = new docx.Styles.TableCellBorders(new docx.Styles.Border(docx.Styles.BorderStyle.Single));
 
@@ -328,18 +328,19 @@ The following steps walk you through the entire process of Exporting the a simpl
 
 5. Traverse all cells of each item which will be contained in the exported file and assign their text to the appropriate cell of the Excel document.In the following code snippet an enumeration with tree values is created which will help you get the items which need to be exported.
 
-	**C#**
+    ```C#
 		private GridItemType[] supportedItemTypes = new GridItemType[] 
         { 
             GridItemType.Header, 
             GridItemType.AlternatingItem, 
             GridItemType.Item 
         };
-	**VB**
+    ```
+    ```VB
 	
 		Private supportedItemTypes As GridItemType() = New GridItemType() {GridItemType.Header, GridItemType.AlternatingItem, GridItemType.Item}
-
-	**C#**
+    ```
+    ```C#
 	
 		foreach (GridItem item in RadGrid1.MasterTableView.GetItems(supportedItemTypes))
 		{
@@ -354,8 +355,8 @@ The following steps walk you through the entire process of Exporting the a simpl
 		    }
 		    currentRow++;
 	}
-
-	**VB**
+    ```
+    ```VB
 
 		For Each item As GridItem In RadGrid1.MasterTableView.GetItems(supportedItemTypes)
 		Dim currentColumn As Integer = 0
@@ -368,6 +369,7 @@ The following steps walk you through the entire process of Exporting the a simpl
 			    currentColumn += 1
 		    Next
 		    currentRow += 1
+    ```
 		Next
 
 
@@ -530,22 +532,23 @@ The following steps walk you through the entire process of creating an Word docu
 
 
 
-	**C#**
+    ```C#
 	
 		RadFlowDocument flowDoc = new RadFlowDocument();
 		Section section = flowDoc.Sections.AddSection();
 		Table table = section.Blocks.AddTable();
-		
-	**VB**
+    ```
+    ```VB
 	
 		Dim flowDoc As New RadFlowDocument()
 		Dim section As Section = flowDoc.Sections.AddSection()
 		Dim table As Table = section.Blocks.AddTable()
+    ```
 
 
 2. Traverse all cells of each item which will be contained in the exported file and assign their text to the appropriate cell of the created Word table.In the following code snippet an enumeration with tree values is created which will help you get the items which need to be exported.
 
-	**C#**
+    ```C#
 	
 		private GridItemType[] supportedItemTypes = new GridItemType[] 
 		    { 
@@ -553,15 +556,16 @@ The following steps walk you through the entire process of creating an Word docu
 		        GridItemType.AlternatingItem, 
 		        GridItemType.Item 
 		    };
-		
-	**VB**
+    ```
+    ```VB
 	
 		Private supportedItemTypes As GridItemType() = New GridItemType() {GridItemType.Header, GridItemType.AlternatingItem, GridItemType.Item}
+    ```
 		
 		
 	
 	
-	**C#**
+    ```C#
 
 		foreach (GridItem item in RadGrid1.MasterTableView.GetItems(supportedItemTypes))
 		    {
@@ -578,7 +582,8 @@ The following steps walk you through the entire process of creating an Word docu
 		        }
 		    }
 	
-	**VB**
+    ```
+    ```VB
 	
 		For Each item As GridItem In RadGrid1.MasterTableView.GetItems(supportedItemTypes)
 		Dim wordRow As Telerik.Windows.Documents.Flow.Model.TableRow = Nothing
@@ -595,6 +600,8 @@ The following steps walk you through the entire process of creating an Word docu
 		Next
 
 
+
+    ```
 
 3. After the worksheet is populated with data an instance of the **DocxFormatProvider** is created and by calling its **Export** method a file is generated on the server.
 

--- a/controls/grid/functionality/filtering/checklist-filtering.md
+++ b/controls/grid/functionality/filtering/checklist-filtering.md
@@ -48,7 +48,7 @@ To specify what values will be displayed in the ListBox control you need to defi
 	**Example 1**
 
 
-	**ASP.NET**
+	```ASP.NET
 
 		<telerik:RadGrid RenderMode="Lightweight" ID="RadGrid1" AllowFilteringByColumn="True" runat="server" FilterType="Combined"
 		    AllowPaging="True" OnFilterCheckListItemsRequested="RadGrid1_FilterCheckListItemsRequested"
@@ -79,8 +79,9 @@ To specify what values will be displayed in the ListBox control you need to defi
 		</telerik:RadGrid>
 		<asp:SqlDataSource ID="SqlDataSource1" runat="server" ConnectionString="<%$ ConnectionStrings:NorthwindConnectionString %>"
 		    SelectCommand="SELECT * FROM [Customers]"></asp:SqlDataSource>
+	```
 
-	**C#**
+	```C#
 
 		protected void RadGrid1_FilterCheckListItemsRequested(object sender, GridFilterCheckListItemsRequestedEventArgs e)
 		{
@@ -115,8 +116,9 @@ To specify what values will be displayed in the ListBox control you need to defi
 
 		    return myDataTable;
 		}
+	```
 
-	**VB**
+	```VB
 
 		Protected Sub RadGrid1_FilterCheckListItemsRequested(sender As Object, e As GridFilterCheckListItemsRequestedEventArgs)
 		    Dim DataField As String = TryCast(e.Column, IGridDataColumn).GetActiveDataField()
@@ -146,6 +148,7 @@ To specify what values will be displayed in the ListBox control you need to defi
 
 		    Return myDataTable
 		End Function
+	```
 
 
 2. By providing a path to a **Web Service** which will provide the data. You specify the path using the **CheckListWebServicePath** property of RadGrid. Beside that you may need to set the name of the method that will provide the actual data to the ListBox control using the **FilterCheckListWebServiceMethod** property if	you have more than one method defined in your web service. (See Example 2)
@@ -154,7 +157,7 @@ To specify what values will be displayed in the ListBox control you need to defi
 
 
 
-	**ASP.NET**
+	```ASP.NET
 
 		<telerik:RadGrid RenderMode="Lightweight" runat="server" ID="RadGrid2" AllowFilteringByColumn="true" FilterType="CheckList"
 		    AllowPaging="true" PagerStyle-AlwaysVisible="true" AllowSorting="true">
@@ -193,8 +196,9 @@ To specify what values will be displayed in the ListBox control you need to defi
 		<asp:SqlDataSource ID="SqlDataSource2" ConnectionString="<%$ ConnectionStrings:NorthwindConnectionString %>"
 		    ProviderName="System.Data.SqlClient" SelectCommand="SELECT * FROM Orders" runat="server">
 		</asp:SqlDataSource>
+	```
 
-	**C#**
+	```C#
 
 		[ServiceKnownType(typeof(Customer))]
 		[ServiceContract(Namespace = "")]
@@ -326,8 +330,8 @@ To specify what values will be displayed in the ListBox control you need to defi
 		        public string Phone { get; set; }
 		    }
 		}
-
-	**VB**
+	```
+	```VB
 
 		<ServiceKnownType(GetType(Customer))> _
 		<ServiceContract([Namespace]:="")> _
@@ -504,6 +508,8 @@ To specify what values will be displayed in the ListBox control you need to defi
 		End Class
 
 
+
+	```
 
 ## FilterType HeaderContext
 

--- a/controls/grid/functionality/paging/changing-the-default-pager/accessing-the-elements-of-advanced-type-pager.md
+++ b/controls/grid/functionality/paging/changing-the-default-pager/accessing-the-elements-of-advanced-type-pager.md
@@ -31,7 +31,7 @@ When using the advanced grid pager/slider, you can customize the properties of t
 
 	**Example**:
 
-	**C#**
+    ```C#
 
 		protected void RadGrid1_ItemDataBound(object sender, GridItemEventArgs e)
 		{
@@ -41,8 +41,9 @@ When using the advanced grid pager/slider, you can customize the properties of t
 		        lblPageSize.Text = "Number of items:";
 		    }
 		}
+    ```
 
-	**VB**
+    ```VB
 
 		Protected Sub RadGrid1_ItemDataBound(sender As Object, e As GridItemEventArgs) Handles RadGrid1.ItemDataBound()
 		    If TypeOf e.Item Is GridPagerItem Then
@@ -50,6 +51,7 @@ When using the advanced grid pager/slider, you can customize the properties of t
 		        lblPageSize.Text = "Number of items:"
 		    End If
 		End Sub
+    ```
 
 
 4. The following table lists the ID's of the controls in the pager when **Mode** is "Advanced" or "Slider":

--- a/controls/grid/how-to/Filtering/filter-with-ms-dropdownlist-instead-of-textbox-.md
+++ b/controls/grid/how-to/Filtering/filter-with-ms-dropdownlist-instead-of-textbox-.md
@@ -30,12 +30,11 @@ The following steps describe how to achieve this result:
 
 The following example illustrates how to create a custom column class that replaces the filter text box with a drop-down list.
 
-**C#**
+```C#
 
 		public class MyCustomFilteringColumn : GridBoundColumn
 		{
 		    private object listDataSource = null;
-		    //RadGrid calls this method when it initializes the controls inside the filtering item cells
 		    protected override void SetupFilterControls(TableCell cell)
 		    {
 		        base.SetupFilterControls(cell);
@@ -95,7 +94,8 @@ The following example illustrates how to create a custom column class that repla
 		}
 
 
-**VB**
+```
+```VB
 
 		Imports Microsoft.VisualBasic
 		Imports Telerik.Web.UI
@@ -168,6 +168,7 @@ The following example illustrates how to create a custom column class that repla
 		        End Class
 
 		    End Namespace
+	```
 
 
 ## Adding custom columns to a grid
@@ -176,14 +177,15 @@ You can add instances of your custom column type **RadGrid** as follows:
 
 1. At the top of the the ASPX page, register the namespace for the custom column class. You do not need to add an Assembly attribute, unless the class is defined in another assembly:
 
-	**ASP.NET**
+	```ASP.NET
 
 		<%@ register namespace="MyStuff" tagprefix="custom" %>
+	```
 
 
 2. You can now add instances of the column type in the declaration of your grid. Note that this example includes a command item with a "Clear" button to clear the selected filters:
 
-	**ASP.NET**
+	```ASP.NET
 
 		<telerik:RadGrid
 		   ID="RadGrid1" runat="server"
@@ -220,6 +222,7 @@ You can add instances of your custom column type **RadGrid** as follows:
 		<asp:SqlDataSource ID="SqlDataSource1" runat="server" ConnectionString="<%$ ConnectionStrings:NorthwindConnectionString %>"
 		    SelectCommand="SELECT * FROM [Orders]">
 		</asp:SqlDataSource>
+	```
 
 
 3. The **MyCustomFilteringColumn** implementation requires a **ListDataSource**. You can set that in the **Page_Load** event handler. In addition, the grid definition above requires an implementation for the "ClearFilters" button:
@@ -227,7 +230,7 @@ You can add instances of your custom column type **RadGrid** as follows:
 	>note This example sets the **ListDataSource** property in the **Page_Load** event handler. If you are binding your grid using the **NeedDataSource** event, it is more appropriate to set the **ListDataSource** in that event handler. (NeedDataSource does not occur when using declarative data binding.)
 	>
 
-	**C#**
+	```C#
 
 		protected void Page_Load(object sender, EventArgs e)
 		{
@@ -270,8 +273,8 @@ You can add instances of your custom column type **RadGrid** as follows:
 		    }
 		}
 
-
-	**VB**
+	```
+	```VB
 
 		Protected Sub Page_Load(ByVal sender As Object, ByVal e As EventArgs) Handles Me.Load
 		    For Each column As GridBoundColumn In RadGrid1.MasterTableView.Columns
@@ -303,6 +306,7 @@ You can add instances of your custom column type **RadGrid** as follows:
 		        RadGrid1.MasterTableView.Rebind()
 		    End If
 		End Sub
+	```
 
 
 

--- a/controls/grid/how-to/ajaxified-grid/postback-from-ajaxified-grid.md
+++ b/controls/grid/how-to/ajaxified-grid/postback-from-ajaxified-grid.md
@@ -26,9 +26,10 @@ If you want to perform postback instead of callback when the grid is AJAX-enable
 
 4. **eventArgs** is an optional argument for the event that lets you pass data to the server.The following example shows how to call the **doPostBack** function, passing information about the currently clicked row of a grid:
 
-	**JavaScript**
+    ```JavaScript
 
 		doPostBack("<%= RadGrid1.UniqueID   %>", "RowClicked:" + this.Rows[index].ItemIndex);
+    ```
 
 
 5. Process the postback in the code-behind of the page (managing the **RaisePostBackEventHandler** in a similar fashion to that presented in [ this knowledge base article ](https://www.telerik.com/support/kb/aspnet-ajax/grid/performing-postback-from-grid-client-events.aspx)). You can check whether the source control that triggers the request is **RadGrid** - then execute some custom logic:

--- a/controls/grid/how-to/data-editing/readonly-option-for-webusercontrol-edit-form.md
+++ b/controls/grid/how-to/data-editing/readonly-option-for-webusercontrol-edit-form.md
@@ -19,7 +19,7 @@ The "preview" functionality for user control edit form is easily achievable. To 
 
 1. Add **GridButtonColumn** to your grid instance with **CommandName = "Preview".**
 
-	**ASP.NET**
+	```ASP.NET
 
 		<MasterTableView CommandItemDisplay="Top" GridLines="None">
 		  <EditFormSettings UserControlName="EmployeeDetailsVB.ascx" EditFormType="WebUserControl">
@@ -43,12 +43,13 @@ The "preview" functionality for user control edit form is easily achievable. To 
 		      </telerik:GridBoundColumn>
 		   </Columns>
 		</MasterTableView>
+	```
 
 2. Handle the **Preview** command execution in your **ItemCommand** event handler and call the **SetPreviewMode**() method to force the user control in preview mode:
 
 
 
-	**VB**
+	```VB
 
 		Private Sub RadGrid1_ItemCommand(ByVal source As Object, ByVal e As Telerik.Web.UI.GridCommandEventArgs) Handles RadGrid1.ItemCommand
 		    If (e.CommandName = "Preview") Then
@@ -60,8 +61,9 @@ The "preview" functionality for user control edit form is easily achievable. To 
 		        MyUserControl.SetPreviewMode()
 		    End If
 		End Sub
+	```
 
-	**C#**
+	```C#
 
 		private void RadGrid1_ItemCommand(object source, Telerik.Web.UI.GridCommandEventArgs e)
 		{
@@ -75,10 +77,11 @@ The "preview" functionality for user control edit form is easily achievable. To 
 		        MyUserControl.SetPreviewMode();
 		    }
 		}
+	```
 
 3. In the **code-behind of the user control disable all controls** which reside in the edit form (except the cancel button) and change the cancel button text to **Close.**
 
-	**C#**
+	```C#
 
 		public void SetPreviewMode()
 		{
@@ -93,8 +96,9 @@ The "preview" functionality for user control edit form is easily achievable. To 
 		    btnCancel.Enabled = true;
 		    btnCancel.Text = "Close";
 		}
+	```
 
-	**VB**
+	```VB
 
 		Public Sub SetPreviewMode()
 		    btnUpdate.Visible = False
@@ -106,6 +110,7 @@ The "preview" functionality for user control edit form is easily achievable. To 
 		    btnCancel.Enabled = True
 		    btnCancel.Text = "Close"
 		End Sub
+	```
 
 
 

--- a/controls/htmlchart/appearance-and-styling/create-custom-skin.md
+++ b/controls/htmlchart/appearance-and-styling/create-custom-skin.md
@@ -34,16 +34,16 @@ To modify an existing chart skin you can follow the steps below:
 
 	>caption Example 1: Customize the Black skin of RadHtmlChart via the `RadHtmlChartSkins.js` file.
 
-	**JavaScript**
-
-		Black: {
-			chart: deepExtend({}, chartBaseTheme, {
-				chartArea: {
-					background: "silver"
-				},
-				seriesColors: ["green", "blue"],
-			})
-		},
+	```JavaScript
+	Black: {
+		chart: deepExtend({}, chartBaseTheme, {
+			chartArea: {
+				background: "silver"
+			},
+			seriesColors: ["green", "blue"],
+		})
+	},
+	```
 
 1. Set the name of the customized skin to the RadHtmlChart and reference the `RadHtmlChartSkins.js` file from the same page where the chart resides.
 

--- a/controls/htmlchart/client-side-programming/overview.md
+++ b/controls/htmlchart/client-side-programming/overview.md
@@ -44,18 +44,18 @@ There are two ways to get a reference to the Kendo Chart widget in order to use 
 
 	>caption **Example 1:** Get the Kendo Chart object through the get_kendoWidget method.
 
-	**JavaScript**
-	
-		var radHtmlChartObject = $find("<%=RadHtmlChart1.ClientID %>"); //the standard script control object
-		var kendoChart = radHtmlChartObject.get_kendoWidget(); //the Kendo widget
+	```JavaScript
+	var radHtmlChartObject = $find("<%=RadHtmlChart1.ClientID %>"); //the standard script control object
+	var kendoChart = radHtmlChartObject.get_kendoWidget(); //the Kendo widget
+	```
 
 * Use the standard Kendo approach for getting the widget through the data-attributes of the DOM element:
 
 	>caption **Example 2:** Get the Kendo Chart object through the data attribute of the DOM object.
 
-	**JavaScript**
-	
-		var kendoChart = $telerik._kendo.jQuery("#<%=RadHtmlChart1.ClientID %>").data("kendoChart");//the jQuery selector must get the RadHtmlChart wrapping div element
+	```JavaScript
+	var kendoChart = $telerik._kendo.jQuery("#<%=RadHtmlChart1.ClientID %>").data("kendoChart");//the jQuery selector must get the RadHtmlChart wrapping div element
+	```
 
 >important As of the 2026 Q1 release, Kendo jQuery widget plugins and data are registered on `$telerik._kendo.jQuery` — a different jQuery instance from `$telerik.$`. If you use `$telerik.$` with `.data("kendoXxx")`, it will return `undefined`. Always use `$telerik._kendo.jQuery` when accessing the underlying Kendo widget via the `.data()` method. The recommended approach, however, is to use the `get_kendoWidget()` method shown above.
 

--- a/controls/htmlchart/functionality/axes/date-axis-base-unit-steps.md
+++ b/controls/htmlchart/functionality/axes/date-axis-base-unit-steps.md
@@ -30,19 +30,19 @@ You can configure a common step for all the base units through the following pro
 	 
 	>caption Example 1: Date axis with BaseUnitStep set to 3 shown in Figure 1.
 		 
-	**ASP.NET**
-
-		<telerik:RadHtmlChart ID="RadHtmlChart1" runat="server" Width="600" Height="400">
-			<PlotArea>
-				<XAxis BaseUnitStep="3" DataLabelsField="SellDate">
-					<LabelsAppearance RotationAngle="45" DataFormatString="d"></LabelsAppearance>
-				</XAxis>
-				<Series>
-					<telerik:LineSeries Name="Series 1" DataFieldY="SellQuantity">
-					</telerik:LineSeries>
-				</Series>
-			</PlotArea>
-		</telerik:RadHtmlChart>
+	```ASP.NET
+	<telerik:RadHtmlChart ID="RadHtmlChart1" runat="server" Width="600" Height="400">
+		<PlotArea>
+			<XAxis BaseUnitStep="3" DataLabelsField="SellDate">
+				<LabelsAppearance RotationAngle="45" DataFormatString="d"></LabelsAppearance>
+			</XAxis>
+			<Series>
+				<telerik:LineSeries Name="Series 1" DataFieldY="SellQuantity">
+				</telerik:LineSeries>
+			</Series>
+		</PlotArea>
+	</telerik:RadHtmlChart>
+	```
 		
 	*Chart data source can be obtained from Example 2 below.*
 
@@ -133,7 +133,7 @@ You can see how the **BaseUnit** property and the corresponding **BaseUnitStep**
 
 >caption Example 3: Setting arrays of steps for different units (e.g., "Months" and "Days"). The output is shown in Figure 3.1.
 
-**ASP.NET**
+```ASP.NET
 
 	<telerik:RadHtmlChart ID="RadHtmlChart1" runat="server" Width="600" Height="400">
 		<PlotArea>
@@ -156,6 +156,7 @@ You can see how the **BaseUnit** property and the corresponding **BaseUnitStep**
 			</Series>
 		</PlotArea>
 	</telerik:RadHtmlChart>
+```
 
 *Chart data source can be obtained from Example 2 above.*
 

--- a/controls/htmlchart/functionality/clienttemplate/display-html-and-execute-javascript.md
+++ b/controls/htmlchart/functionality/clienttemplate/display-html-and-execute-javascript.md
@@ -20,108 +20,108 @@ ClientTemplates let you use JavaScript, following this pattern: `"#if (condition
 
 * **If Statement**:
 
-	**ASP.NET**
-	
-		<telerik:RadHtmlChart ID="RadHtmlChart1" runat="server" Width="300px" Height="300px">
-			<PlotArea>
-				<Series>
-					<telerik:PieSeries>
-						<LabelsAppearance>
-							<ClientTemplate>
-		#if (percentage > 0.15) {# #=value# #} else {# 0 #} #
-							</ClientTemplate>
-						</LabelsAppearance>
-						<TooltipsAppearance>
-							<ClientTemplate>
-		#if (percentage > 0.15) {# #=value# #} else {# 0 #} #
-							</ClientTemplate>
-						</TooltipsAppearance>
-						<SeriesItems>
-							<telerik:PieSeriesItem Y="30" />
-							<telerik:PieSeriesItem Y="60" />
-							<telerik:PieSeriesItem Y="10" />
-						</SeriesItems>
-					</telerik:PieSeries>
-				</Series>
-			</PlotArea>
-		</telerik:RadHtmlChart>
+	```ASP.NET
+	<telerik:RadHtmlChart ID="RadHtmlChart1" runat="server" Width="300px" Height="300px">
+		<PlotArea>
+			<Series>
+				<telerik:PieSeries>
+					<LabelsAppearance>
+						<ClientTemplate>
+	#if (percentage > 0.15) {# #=value# #} else {# 0 #} #
+						</ClientTemplate>
+					</LabelsAppearance>
+					<TooltipsAppearance>
+						<ClientTemplate>
+	#if (percentage > 0.15) {# #=value# #} else {# 0 #} #
+						</ClientTemplate>
+					</TooltipsAppearance>
+					<SeriesItems>
+						<telerik:PieSeriesItem Y="30" />
+						<telerik:PieSeriesItem Y="60" />
+						<telerik:PieSeriesItem Y="10" />
+					</SeriesItems>
+				</telerik:PieSeries>
+			</Series>
+		</PlotArea>
+	</telerik:RadHtmlChart>
+	```
 
 	Only PieSeries/DonutSeries items whose percentage of the whole is higher than 15% will display their actual value in tooltips and labels. The rest of the series items will display a zero value.
 
 * **For Loop**:
 
-	**ASP.NET**
-			
-		<telerik:RadHtmlChart runat="server" ID="RadHtmlChart1" Width="800" Height="500">
-			<PlotArea>
-				<CommonTooltipsAppearance Shared="true">
-					<SharedTemplate>
-				<div>GDP in #= category #</div>
-				 # for (var i = 0; i < points.length; i++) { # 
-				<div>#: points[i].series.name#: #: points[i].value #</div>
-				# } #
-					</SharedTemplate>
-				</CommonTooltipsAppearance>
-				<XAxis>
-					<Items>
-						<telerik:AxisItem LabelText="1999"></telerik:AxisItem>
-						<telerik:AxisItem LabelText="2000"></telerik:AxisItem>
-					</Items>
-				</XAxis>
-				<Series>
-					<telerik:ColumnSeries Name="Transport">
-						<SeriesItems>
-							<telerik:CategorySeriesItem Y="32735.7"></telerik:CategorySeriesItem>
-							<telerik:CategorySeriesItem Y="37911.3"></telerik:CategorySeriesItem>
-						</SeriesItems>
-					</telerik:ColumnSeries>
-					<telerik:ColumnSeries Name="Community">
-						<SeriesItems>
-							<telerik:CategorySeriesItem Y="12453.9"></telerik:CategorySeriesItem>
-							<telerik:CategorySeriesItem Y="14394.3"></telerik:CategorySeriesItem>
-						</SeriesItems>
-					</telerik:ColumnSeries>
-				</Series>
-			</PlotArea>
-		</telerik:RadHtmlChart>
+	```ASP.NET
+	<telerik:RadHtmlChart runat="server" ID="RadHtmlChart1" Width="800" Height="500">
+		<PlotArea>
+			<CommonTooltipsAppearance Shared="true">
+				<SharedTemplate>
+					<div>GDP in #= category #</div>
+					# for (var i = 0; i < points.length; i++) { # 
+					<div>#: points[i].series.name#: #: points[i].value #</div>
+					# } #
+				</SharedTemplate>
+			</CommonTooltipsAppearance>
+			<XAxis>
+				<Items>
+					<telerik:AxisItem LabelText="1999"></telerik:AxisItem>
+					<telerik:AxisItem LabelText="2000"></telerik:AxisItem>
+				</Items>
+			</XAxis>
+			<Series>
+				<telerik:ColumnSeries Name="Transport">
+					<SeriesItems>
+						<telerik:CategorySeriesItem Y="32735.7"></telerik:CategorySeriesItem>
+						<telerik:CategorySeriesItem Y="37911.3"></telerik:CategorySeriesItem>
+					</SeriesItems>
+				</telerik:ColumnSeries>
+				<telerik:ColumnSeries Name="Community">
+					<SeriesItems>
+						<telerik:CategorySeriesItem Y="12453.9"></telerik:CategorySeriesItem>
+						<telerik:CategorySeriesItem Y="14394.3"></telerik:CategorySeriesItem>
+					</SeriesItems>
+				</telerik:ColumnSeries>
+			</Series>
+		</PlotArea>
+	</telerik:RadHtmlChart>
+	```
 
 	The tooltip will display three lines of text. The first line shows the category and the next two lines show the Y-values of both items from this category.
 
 * **Call a function**
 
-	**ASP.NET**
-
-			<script>
-				function formatLabel(number) {
-					if (number < 1000)
-						return number;
-					if (number < 1000000)
-						return number / 1000 + "K";
-					if (number < 1000000000)
-						return number / 1000000 + "M";
-				}
-			</script>
-			<telerik:RadHtmlChart runat="server" ID="BarChart1" Width="800px" Height="300px">
-				<PlotArea>
-					<YAxis>
-						<TitleAppearance Text="Quantity" />
-						<LabelsAppearance>
-							<ClientTemplate>
-								#= formatLabel(value) #
-							</ClientTemplate>
-						</LabelsAppearance>
-					</YAxis>
-					<Series>
-						<telerik:BarSeries Name="Product A">
-							<SeriesItems>
-								<telerik:CategorySeriesItem Y="100" />
-								<telerik:CategorySeriesItem Y="20000" />
-								<telerik:CategorySeriesItem Y="1000000" />
-							</SeriesItems>
-						</telerik:BarSeries>
-					</Series>
-				</PlotArea>
-			</telerik:RadHtmlChart>
+	```ASP.NET
+	<script>
+		function formatLabel(number) {
+			if (number < 1000)
+				return number;
+			if (number < 1000000)
+				return number / 1000 + "K";
+			if (number < 1000000000)
+				return number / 1000000 + "M";
+		}
+	</script>
+	<telerik:RadHtmlChart runat="server" ID="BarChart1" Width="800px" Height="300px">
+		<PlotArea>
+			<YAxis>
+				<TitleAppearance Text="Quantity" />
+				<LabelsAppearance>
+					<ClientTemplate>
+						#= formatLabel(value) #
+					</ClientTemplate>
+				</LabelsAppearance>
+			</YAxis>
+			<Series>
+				<telerik:BarSeries Name="Product A">
+					<SeriesItems>
+						<telerik:CategorySeriesItem Y="100" />
+						<telerik:CategorySeriesItem Y="20000" />
+						<telerik:CategorySeriesItem Y="1000000" />
+					</SeriesItems>
+				</telerik:BarSeries>
+			</Series>
+		</PlotArea>
+	</telerik:RadHtmlChart>
+	```
 
 ## Display HTML with a ClientTemplate
 

--- a/controls/htmlchart/functionality/clienttemplate/overview.md
+++ b/controls/htmlchart/functionality/clienttemplate/overview.md
@@ -120,18 +120,18 @@ You can set the following properties for a **ClientTemplate**:
 	* **PieSeries/DonutSeries** - Returns the value set in the **Name** property of the series item for a non-data bound chart and the corresponding value from the **NameField** column of the data source for a data bound chart.
 
 	
-	**ASP.NET**
-	
-		<LabelsAppearance>
-			<ClientTemplate>
-				Category: #=category#
-			</ClientTemplate>
-		</LabelsAppearance>
-		<TooltipsAppearance>
-			<ClientTemplate>
-				Category: #=category#
-			</ClientTemplate>
-		</TooltipsAppearance>
+	```ASP.NET
+	<LabelsAppearance>
+		<ClientTemplate>
+			Category: #=category#
+		</ClientTemplate>
+	</LabelsAppearance>
+	<TooltipsAppearance>
+		<ClientTemplate>
+			Category: #=category#
+		</ClientTemplate>
+	</TooltipsAppearance>
+	```
 
 * **dataItem** - Returns the original data item used to construct the point. You can see more information about using the **dataItem** object in a **ClientTemplate** in the previous section of this article — *Showing DataBase Values Using a ClientTemplate*.
 
@@ -151,106 +151,106 @@ You can set the following properties for a **ClientTemplate**:
 
 		* **custom string** - The string set in the **GroupName** property that clusters series in stacked groups.
 
-	**ASP.NET**
-
-		<LabelsAppearance>
-			<ClientTemplate>
-				Series Name: #=series.name# , Series Type: #=series.type# , Series Stack Status: #=series.stack #
-			</ClientTemplate>
-		</LabelsAppearance>
-		<TooltipsAppearance>
-			<ClientTemplate>
-				Series Name: #=series.name# <br/> 
-				Series Type: #=series.type# </br> 
-				Series Stack Status: #=series.stack #
-			</ClientTemplate>
-		</TooltipsAppearance>
+	```ASP.NET
+	<LabelsAppearance>
+		<ClientTemplate>
+			Series Name: #=series.name# , Series Type: #=series.type# , Series Stack Status: #=series.stack #
+		</ClientTemplate>
+	</LabelsAppearance>
+	<TooltipsAppearance>
+		<ClientTemplate>
+			Series Name: #=series.name# <br/> 
+			Series Type: #=series.type# </br> 
+			Series Stack Status: #=series.stack #
+		</ClientTemplate>
+	</TooltipsAppearance>
+	```
 
 * **value** - Returns the point value (either a number or an object).
 
 	* **BubbleSeries** - Returns an object that exposes three fields: x, y and size.
 
-		**ASP.NET**
-	
-			<LabelsAppearance>
-				<ClientTemplate>
-					X Value: #=value.x# , Y Value: #=value.y# , Size Value: #=value.size #
-				</ClientTemplate>
-			</LabelsAppearance>
-			<TooltipsAppearance>
-				<ClientTemplate>
-					X Value: #=value.x# <br/> 
-					Y Value: #=value.y# <br/> 
-					Size Value: #=value.size #
-				</ClientTemplate>
-			</TooltipsAppearance>
+		```ASP.NET
+		<LabelsAppearance>
+			<ClientTemplate>
+				X Value: #=value.x# , Y Value: #=value.y# , Size Value: #=value.size #
+			</ClientTemplate>
+		</LabelsAppearance>
+		<TooltipsAppearance>
+			<ClientTemplate>
+				X Value: #=value.x# <br/> 
+				Y Value: #=value.y# <br/> 
+				Size Value: #=value.size #
+			</ClientTemplate>
+		</TooltipsAppearance>
+		```
 
 
 	* **CandlestickSeries** - Returns an object that exposes four fields: open, high, low and close.
 
-		**ASP.NET**
-		
-			<TooltipsAppearance>
-				<ClientTemplate>
-					Open Value: #=value.open# <br/> 
-					High Value: #=value.high# <br/> 
-					Low Value: #=value.low # <br/> 
-					Close Value: #=value.close #
-				</ClientTemplate> 
-			</TooltipsAppearance>
+		```ASP.NET
+		<TooltipsAppearance>
+			<ClientTemplate>
+				Open Value: #=value.open# <br/> 
+				High Value: #=value.high# <br/> 
+				Low Value: #=value.low # <br/> 
+				Close Value: #=value.close #
+			</ClientTemplate> 
+		</TooltipsAppearance>
+		```
 
 	* **ScatterSeries** and **ScatterLineSeries** - Returns an object that exposes the x and y fields for the X-value and the Y-value of the item.
 
-		**ASP.NET**
-		
-			<LabelsAppearance>
-				<ClientTemplate>
-					X Value: #=value.x# , Y Value: #=value.y#
-				</ClientTemplate>
-			</LabelsAppearance>
-			<TooltipsAppearance>
-				<ClientTemplate>
-					X Value: #=value.x# <br/> 
-					Y Value: #=value.y#
-				</ClientTemplate>=""
-			</TooltipsAppearance>
+		```ASP.NET
+		<LabelsAppearance>
+			<ClientTemplate>
+				X Value: #=value.x# , Y Value: #=value.y#
+			</ClientTemplate>
+		</LabelsAppearance>
+		<TooltipsAppearance>
+			<ClientTemplate>
+				X Value: #=value.x# <br/> 
+				Y Value: #=value.y#
+			</ClientTemplate>=""
+		</TooltipsAppearance>
+		```
 
 	* **BoxPlot** - Returns an object that exposes the `lower`, `q1`, `median`, `mean`, `median`, `q3` and `upper` fields that contain the values from the corresponding fields of the series object.
 
-		**ASP.NET**
-		
-			<TooltipsAppearance>
-				<ClientTemplate>
-					<table cellpadding=7><tr><td><b>#= category #<br /> Lower: #=value.lower# <br /> Q1: #=value.q1# <br /> Median: #=value.median# <br /> Mean: #=value.mean# <br /> Q3: #=value.q3# <br /> Upper #=value.upper#</b></td></tr></table>
-				</ClientTemplate>=""
-			</TooltipsAppearance>
+		```ASP.NET
+		<TooltipsAppearance>
+			<ClientTemplate>
+				<table cellpadding=7><tr><td><b>#= category #<br /> Lower: #=value.lower# <br /> Q1: #=value.q1# <br /> Median: #=value.median# <br /> Mean: #=value.mean# <br /> Q3: #=value.q3# <br /> Upper #=value.upper#</b></td></tr></table>
+			</ClientTemplate>=""
+		</TooltipsAppearance>
+		```
 
 	* **BulletSeries** and **VerticalBulletSeries** - Returns an object that exposes the `current` and `target` fields that contain the values from the corresponding fields of the series item object.
 
-		**ASP.NET**
-		
-			<TooltipsAppearance>
-			    <ClientTemplate>
-			            current value is #=value.current#
-			            <br />
-			            desired value is: #=value.target#
-			    </ClientTemplate>
-			</TooltipsAppearance>
+		```ASP.NET
+		<TooltipsAppearance>
+		    <ClientTemplate>
+		            current value is #=value.current#
+		            <br />
+		            desired value is: #=value.target#
+		    </ClientTemplate>
+		</TooltipsAppearance>
+		```
 
 	* **Other Series Types** - Returns the Y value of the hovered series Item.
 
-		**ASP.NET**
-		
-			<LabelsAppearance>
-				<ClientTemplate>
-					Y Value: #=value#
-				</ClientTemplate>
-			</LabelsAppearance>
-			<TooltipsAppearance>
-				<ClientTemplate>
-					Y Value: #=value#
-				</ClientTemplate> 
-			</TooltipsAppearance>
+		```ASP.NET
+		<LabelsAppearance>
+			<ClientTemplate>
+				Y Value: #=value#
+			</ClientTemplate>
+		</LabelsAppearance>
+		<TooltipsAppearance>
+			<ClientTemplate>
+				Y Value: #=value#
+			</ClientTemplate> 
+		</TooltipsAppearance>
+		```
 
 ## See Also
 

--- a/controls/htmlchart/functionality/visual-template.md
+++ b/controls/htmlchart/functionality/visual-template.md
@@ -25,57 +25,57 @@ The function that will create the custom visual receives arguments that provide 
 
 1. Create a chart (this example adds static items and settings in the markup) and ensure that you have set the desired **Visual** properties accordingly.
 
-	**ASP.NET**
-
-		<telerik:RadHtmlChart runat="server" ID="RadHtmlChart1" Width="800px" Height="400px">
-			<ClientEvents OnLoad="onChartLoad" />
-			<Legend>
-				<Appearance Position="Bottom" />
-				<Item Visual="legendItemVisual" />
-			</Legend>
-			<PlotArea>
-				<Series>
-					<telerik:ColumnSeries Name="Product 1">
-						<Appearance Visual="columnVisual"></Appearance>
-						<LabelsAppearance Visible="false"></LabelsAppearance>
-						<TooltipsAppearance DataFormatString="{0:c}"></TooltipsAppearance>
-						<SeriesItems>
-							<telerik:CategorySeriesItem Y="101022" />
-							<telerik:CategorySeriesItem Y="135005" />
-							<telerik:CategorySeriesItem Y="180004" />
-						</SeriesItems>
-					</telerik:ColumnSeries>
-					<telerik:LineSeries Name="Target">
-						<MarkersAppearance Visual="markersVisual" />
-						<LineAppearance Width="0" />
-						<LabelsAppearance Visible="false"></LabelsAppearance>
-						<TooltipsAppearance DataFormatString="{0:c}"></TooltipsAppearance>
-						<SeriesItems>
-							<telerik:CategorySeriesItem Y="90000" />
-							<telerik:CategorySeriesItem Y="125000" />
-							<telerik:CategorySeriesItem Y="145000" />
-						</SeriesItems>
-					</telerik:LineSeries>
-				</Series>
-				<YAxis Step="40000">
-					<LabelsAppearance DataFormatString="{0:c}" />
-					<MinorGridLines Visible="false" />
-				</YAxis>
-				<XAxis>
-					<MinorGridLines Visible="false" />
-					<LabelsAppearance>
-						<TextStyle Margin="10 0 0 0" />
-					</LabelsAppearance>
-					<Items>
-						<telerik:AxisItem LabelText="Q1" />
-						<telerik:AxisItem LabelText="Q2" />
-						<telerik:AxisItem LabelText="Q3" />
-					</Items>
-				</XAxis>
-			</PlotArea>
-			<ChartTitle Text="Product sales for 2014">
-			</ChartTitle>
-		</telerik:RadHtmlChart>
+	```ASP.NET
+	<telerik:RadHtmlChart runat="server" ID="RadHtmlChart1" Width="800px" Height="400px">
+		<ClientEvents OnLoad="onChartLoad" />
+		<Legend>
+			<Appearance Position="Bottom" />
+			<Item Visual="legendItemVisual" />
+		</Legend>
+		<PlotArea>
+			<Series>
+				<telerik:ColumnSeries Name="Product 1">
+					<Appearance Visual="columnVisual"></Appearance>
+					<LabelsAppearance Visible="false"></LabelsAppearance>
+					<TooltipsAppearance DataFormatString="{0:c}"></TooltipsAppearance>
+					<SeriesItems>
+						<telerik:CategorySeriesItem Y="101022" />
+						<telerik:CategorySeriesItem Y="135005" />
+						<telerik:CategorySeriesItem Y="180004" />
+					</SeriesItems>
+				</telerik:ColumnSeries>
+				<telerik:LineSeries Name="Target">
+					<MarkersAppearance Visual="markersVisual" />
+					<LineAppearance Width="0" />
+					<LabelsAppearance Visible="false"></LabelsAppearance>
+					<TooltipsAppearance DataFormatString="{0:c}"></TooltipsAppearance>
+					<SeriesItems>
+						<telerik:CategorySeriesItem Y="90000" />
+						<telerik:CategorySeriesItem Y="125000" />
+						<telerik:CategorySeriesItem Y="145000" />
+					</SeriesItems>
+				</telerik:LineSeries>
+			</Series>
+			<YAxis Step="40000">
+				<LabelsAppearance DataFormatString="{0:c}" />
+				<MinorGridLines Visible="false" />
+			</YAxis>
+			<XAxis>
+				<MinorGridLines Visible="false" />
+				<LabelsAppearance>
+					<TextStyle Margin="10 0 0 0" />
+				</LabelsAppearance>
+				<Items>
+					<telerik:AxisItem LabelText="Q1" />
+					<telerik:AxisItem LabelText="Q2" />
+					<telerik:AxisItem LabelText="Q3" />
+				</Items>
+			</XAxis>
+		</PlotArea>
+		<ChartTitle Text="Product sales for 2014">
+		</ChartTitle>
+	</telerik:RadHtmlChart>
+	```
 
 
 1. Add the scripts that will render the desired shapes:

--- a/controls/htmlchart/how-to/export-to-pdf-with-clientexportmanager.md
+++ b/controls/htmlchart/how-to/export-to-pdf-with-clientexportmanager.md
@@ -16,40 +16,40 @@ The following steps will enable you to easily implement the export functionality
 
 1. Add the **RadClientExportManager** in the page's markup:
 
-	**ASP.NET**
-
-		<telerik:RadClientExportManager runat="server" ID="RadClientExportManager1">
-	    </telerik:RadClientExportManager>
+    ```ASP.NET
+    <telerik:RadClientExportManager runat="server" ID="RadClientExportManager1">
+    </telerik:RadClientExportManager>
+    ```
 
 1. Add a button with a client-side click handler that will initiate the export:
 
-	**ASP.NET**
-
-		<telerik:RadButton RenderMode="Lightweight" runat="server" OnClientClicked="exportChart" Text="Export" AutoPostBack="false" />
-		
-		<script>
-			function exportChart() {
-			    // ToDo: Export the chart.
-			}
-		</script>
+    ```ASP.NET
+    <telerik:RadButton RenderMode="Lightweight" runat="server" OnClientClicked="exportChart" Text="Export" AutoPostBack="false" />
+	
+    <script>
+        function exportChart() {
+            // ToDo: Export the chart.
+        }
+    </script>
+    ```
 
 1. Use the [client-side API of RadClientExportManager]({%slug clientexportmanager/client-side-programming/overview%}) to export the **RadHtmlChart** wrapper to either PDF: 
 
-	**JavaScript**	
-
-		function exportChart() {
-			var $ = $telerik.$;
-			$find('<%=RadClientExportManager1.ClientID%>').exportPDF($(".RadHtmlChart"));
-		}
+    ```JavaScript
+    function exportChart() {
+        var $ = $telerik.$;
+        $find('<%=RadClientExportManager1.ClientID%>').exportPDF($(".RadHtmlChart"));
+    }
+    ```
 	
 	or image:
 
-	**JavaScript**
-
-		function exportChart() {
-			var $ = $telerik.$;
-			$find('<%=RadClientExportManager1.ClientID%>').exportImage($(".RadHtmlChart"));
-		}
+    ```JavaScript
+    function exportChart() {
+        var $ = $telerik.$;
+        $find('<%=RadClientExportManager1.ClientID%>').exportImage($(".RadHtmlChart"));
+    }
+    ```
 
 
 >caption Example 1: Export RadHtmlChart to PDF or image.

--- a/controls/htmlchart/how-to/implementing-drill-down-functionality.md
+++ b/controls/htmlchart/how-to/implementing-drill-down-functionality.md
@@ -22,13 +22,13 @@ The online demo	[Drill-Down Chart](https://demos.telerik.com/aspnet-ajax/htmlcha
 
 	>caption Example 1.1: Send information about the clicked series to the Server.
 
-	**ASP.NET**
-	
-		<script type="text/javascript">
-			function OnSeriesClick(args) {
-				if (args.series.name != "Months") $find("<%= RadAjaxManager1.ClientID %>").ajaxRequest(args.category);
-			}
-		</script>
+	```ASP.NET
+	<script type="text/javascript">
+		function OnSeriesClick(args) {
+			if (args.series.name != "Months") $find("<%= RadAjaxManager1.ClientID %>").ajaxRequest(args.category);
+		}
+	</script>
+	```
 
 
 1. On the server-side, handle the AJAX request an, depending on the current level of data presentation and the clicked series item, change	the data source and the settings of **RadHtmlChart**. As shown in **Example 1.2**, if the	current name of the series is "Years", the year	corresponding to the clicked series item is retrieved and it is used as a parameter for the **RadHtmlChart** data source, as the new data	should be from the selected year. Also, the properties of the chart control are modified to match the new level of presentation and	a new data source that will provide the new data is specified.

--- a/controls/imageeditor/accessibility-and-internationalization/localization.md
+++ b/controls/imageeditor/accessibility-and-internationalization/localization.md
@@ -42,18 +42,18 @@ The following steps demonstrate how to create a new language pack for **RadImage
 
 1. Set the RadImageEditor’s Language property to the corresponding language:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadImageEditor RenderMode="Lightweight" runat="server" ID="RadImageEditor1" Language="bg-BG">
+	</telerik:RadImageEditor>
+	```
 
-		<telerik:RadImageEditor RenderMode="Lightweight" runat="server" ID="RadImageEditor1" Language="bg-BG">
-		</telerik:RadImageEditor>
+	```C#
+	RadImageEditor1.Language = "bg-BG";
+	```
 
-	**C#**
-
-		RadImageEditor1.Language = "bg-BG";
-
-	**VB**
-
-		RadImageEditor1.Language = "bg-BG"
+	```VB
+	RadImageEditor1.Language = "bg-BG"
+	```
 
 
 

--- a/controls/linkbutton/appearance-and-styling/create-a-custom-skin.md
+++ b/controls/linkbutton/appearance-and-styling/create-a-custom-skin.md
@@ -40,15 +40,15 @@ The second file represents the actual skin of the control, and its name consists
 
 1. Add a new server declaration of **RadLinkButton** on your page, and set **Skin="MyCustomSkin"** and **EnableEmbeddedSkins="false"**:
 
-	**ASP.NET**
-
-		<telerik:RadLinkButton ID="RadLinkButton1" runat="server" EnableEmbeddedSkins="false" Skin="MyCustomSkin" NavigateUrl="https://www.telerik.com" Target="_blank" />
+	```ASP.NET
+	<telerik:RadLinkButton ID="RadLinkButton1" runat="server" EnableEmbeddedSkins="false" Skin="MyCustomSkin" NavigateUrl="https://www.telerik.com" Target="_blank" />
+	```
 
 1. Register **Button.MyCustomSkin.css** in the head section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 
-	**ASP.NET**
-
-		<link href="Skins/MyCustomSkin/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+	```ASP.NET
+	<link href="Skins/MyCustomSkin/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+	```
 
 1. Make sure the path to the files is correct; otherwise the skin will not apply;
 

--- a/controls/linkbutton/client-side-programming/events/overview.md
+++ b/controls/linkbutton/client-side-programming/events/overview.md
@@ -26,7 +26,7 @@ To handle the desired event, the user must set the respective property to the na
 
 * Passing named (non-anonymous) JavaScript function
 
-	**ASP.NET**
+	```ASP.NET
 
 		<script type="text/javascript">
 			function Click(sender, args)
@@ -36,18 +36,21 @@ To handle the desired event, the user must set the respective property to the na
 		</script>
 		<telerik:RadLinkButton ID="RadLinkButton1" runat="server" Text="Click" OnClientClicked="Click" NavigateUrl="https://www.telerik.com" Target="_blank">
 		</telerik:RadLinkButton>
+	```
 
-	**C#**
+	```C#
 
 		RadLinkButton1.OnClientClicked = "Click";  //passing the name of the JS function
+	```
 
-	**VB**
+	```VB
 
 		RadLinkButton1.OnClientClicked = "Click"  'passing the name of the JS function
+	```
 
 * Passing anonymous JavaScript function
 
-	**ASP.NET**
+	```ASP.NET
 
 		<script type="text/javascript">
 			function Click(button, args, arg1, arg2)
@@ -57,14 +60,17 @@ To handle the desired event, the user must set the respective property to the na
 		</script>
 		<telerik:RadLinkButton ID="RadLinkButton1" runat="server" Text="Click" OnClientClicked="function(sender,args){Click(sender, args, 'Value1', 'Value2');}" NavigateUrl="https://www.telerik.com" Target="_blank">
 		</telerik:RadLinkButton>
+	```
 
-	**C#**
+	```C#
 
 		RadLinkButton1.OnClientClicked = "function(sender,args){Click(sender, args, 'Value1', 'Value2');}"; //passing the name of the JS function
+	```
 
-	**VB**
+	```VB
 
 		RadLinkButton1.OnClientClicked = "function(sender,args){Click(sender, args, 'Value1', 'Value2');}"  'passing the name of the JS function
+	```
 
 You can also assign event handlers in client-side code. For more information see the [Setting Event Handlers via JavaScript article]({%slug linkbutton/client-side-programming/events/setting-event-handlers-via-javascript%}).
 

--- a/controls/linkbutton/client-side-programming/events/setting-event-handlers-via-javascript.md
+++ b/controls/linkbutton/client-side-programming/events/setting-event-handlers-via-javascript.md
@@ -18,7 +18,7 @@ Here is an example showing how to add handler on the client:
 
 * Adding named (non-anonymous) JavaScript function
 
-	**ASP.NET**
+	```ASP.NET
 
 		<script type="text/javascript">
 			function Click(button, args)
@@ -31,10 +31,11 @@ Here is an example showing how to add handler on the client:
 				button.add_clicked(Click);
 			}
 		</script>
+	```
 
 * Adding anonymous JavaScript function
 
-	**ASP.NET**
+	```ASP.NET
 
 		<script type="text/javascript">
 			function Click(button, args, arg1)
@@ -47,6 +48,7 @@ Here is an example showing how to add handler on the client:
 				button.add_clicked(function (button, args) { Click(button, args, "Value1") });
 			}
 		</script>
+	```
 	
 >caption A list with the available methods
 

--- a/controls/linkbutton/functionality/Icons/custom-icons.md
+++ b/controls/linkbutton/functionality/Icons/custom-icons.md
@@ -56,25 +56,25 @@ You can use custom font icons in **RadLinkButton** as well. To do that, follow t
 
 1. Load the stylesheet with the desired font icons on the page.
 
-	**CSS**
-
-		<link rel="stylesheet" href="myCustomFontStyleSheet.css" />
+	```CSS
+	<link rel="stylesheet" href="myCustomFontStyleSheet.css" />
+	```
 
 1. Override the font-family of the button's icon element with the target one (see **Example 3**).
 
-	**CSS**
-
-		button.RadButton .rbIcon:before {
-			font-family: myCustomFont;
-		}
+	```CSS
+	button.RadButton .rbIcon:before {
+		font-family: myCustomFont;
+	}
+	```
 
 1. Set the custom font icon class to the **Icon.CssClass** property.
 
-	**ASP.NET**
-
-		<telerik:RadLinkButton ID="RadButton1" runat="server" Text="Button With Custom Font Icon" NavigateUrl="https://www.telerik.com" Target="_blank">
-			<Icon CssClass="myCustomFontIconClass" />
-		</telerik:RadLinkButton>
+	```ASP.NET
+	<telerik:RadLinkButton ID="RadButton1" runat="server" Text="Button With Custom Font Icon" NavigateUrl="https://www.telerik.com" Target="_blank">
+		<Icon CssClass="myCustomFontIconClass" />
+	</telerik:RadLinkButton>
+	```
 
 You can find below an example with [Font Awesome Icons](https://github.com/FortAwesome/Font-Awesome).
 

--- a/controls/linkbutton/functionality/contenttemplate.md
+++ b/controls/linkbutton/functionality/contenttemplate.md
@@ -26,7 +26,7 @@ In order to add controls to the **RadLinkButton** in the markup, you should plac
 
 >caption Example 1: Adding controls to **ContentTemplate** of **RadLinkButton** in the markup.
 
-**ASP.NET**
+```ASP.NET
 
 	<telerik:RadLinkButton runat="server" ID="RadLinkButton1" NavigateUrl="https://www.telerik.com" Target="_blank">
 		<ContentTemplate>
@@ -35,6 +35,7 @@ In order to add controls to the **RadLinkButton** in the markup, you should plac
 			<div>Tasks</div>
 		</ContentTemplate>
 	</telerik:RadLinkButton>
+```
 
 ## Add Elements to RadLinkButton from the Code-behind
 
@@ -44,96 +45,96 @@ You can add controls to **RadLinkButton** from the code-behind in two ways:
 
 	**Example 2**: Adding controls to the **Controls** collection of **RadLinkButton** from the code-behind.
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadLinkButton runat="server" ID="RadLinkButton1" Width="160px" Height="85px" NavigateUrl="https://www.telerik.com" Target="_blank">
+	</telerik:RadLinkButton>
+	```
 
-		<telerik:RadLinkButton runat="server" ID="RadLinkButton1" Width="160px" Height="85px" NavigateUrl="https://www.telerik.com" Target="_blank">
-		</telerik:RadLinkButton>
-
-	**C#**
-
-		protected void Page_Init(object sender, EventArgs e)
+	```C#
+	protected void Page_Init(object sender, EventArgs e)
+	{
+		Image buttonContentImage = new Image()
 		{
-			Image buttonContentImage = new Image()
-			{
-				ID = "buttonContent",
-				AlternateText = "my car",
-				ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/car.png"
-			};
-			Label buttonContentLabel = new Label() { ID = "Label1", Text = "Vehicles" };
-			RadPushButton1.Controls.Add(buttonContentImage);
-			RadPushButton1.Controls.Add(buttonContentLabel);
-		}
+			ID = "buttonContent",
+			AlternateText = "my car",
+			ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/car.png"
+		};
+		Label buttonContentLabel = new Label() { ID = "Label1", Text = "Vehicles" };
+		RadPushButton1.Controls.Add(buttonContentImage);
+		RadPushButton1.Controls.Add(buttonContentLabel);
+	}
+	```
 
-	**VB**
-
-		Protected Sub Page_Init(sender As Object, e As EventArgs)
-			Dim buttonContentImage As New Image() With {
-				.ID = "buttonContent",
-				.AlternateText = "my car",
-				.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/car.png"
+	```VB
+	Protected Sub Page_Init(sender As Object, e As EventArgs)
+		Dim buttonContentImage As New Image() With {
+			.ID = "buttonContent",
+			.AlternateText = "my car",
+			.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/car.png"
 			}
-			Dim buttonContentLabel As New Label() With {
-			   .ID = "Label1",
-			   .Text = "Vehicles"
+		Dim buttonContentLabel As New Label() With {
+		   .ID = "Label1",
+		   .Text = "Vehicles"
 			}
-			RadPushButton1.Controls.Add(buttonContentImage)
-			RadPushButton1.Controls.Add(buttonContentLabel)
-		End Sub
+		RadPushButton1.Controls.Add(buttonContentImage)
+		RadPushButton1.Controls.Add(buttonContentLabel)
+	End Sub
+	```
 
 * Set the **ContentTemplate** property to an instance of a class that implements the **ITemplate** interface (**Example 3**).
 
 	**Example 3**: Adding controls to the **RadLinkButton** by using the **ITemplate** class.
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadLinkButton runat="server" ID="RadLinkButton1" Width="71px" Height="70px" NavigateUrl="https://www.telerik.com" Target="_blank">
+	</telerik:RadLinkButton>
+	```
 
-		<telerik:RadLinkButton runat="server" ID="RadLinkButton1" Width="71px" Height="70px" NavigateUrl="https://www.telerik.com" Target="_blank">
-		</telerik:RadLinkButton>
+	```C#
+	protected void Page_Init(object sender, EventArgs e)
+	{
+		RadLinkButton1.ContentTemplate = new ButtonContentTemplate();
+	}
 
-	**C#**
-
-		protected void Page_Init(object sender, EventArgs e)
+	public class ButtonContentTemplate : ITemplate
+	{
+		void ITemplate.InstantiateIn(Control container)
 		{
-			RadLinkButton1.ContentTemplate = new ButtonContentTemplate();
+			System.Web.UI.WebControls.Image contentImage = new System.Web.UI.WebControls.Image();
+			contentImage.ID = "contentImage";
+			contentImage.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/envelope.png";
+			contentImage.AlternateText = "envelope";
+			container.Controls.Add(contentImage);
+
+			Label contentLabel = new Label();
+			contentLabel.ID = "contentLabel";
+			contentLabel.Text = "E-Mail";
+			container.Controls.Add(contentLabel);
 		}
+	}
+	```
 
-		public class ButtonContentTemplate : ITemplate
-		{
-			void ITemplate.InstantiateIn(Control container)
-			{
-				System.Web.UI.WebControls.Image contentImage = new System.Web.UI.WebControls.Image();
-				contentImage.ID = "contentImage";
-				contentImage.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/envelope.png";
-				contentImage.AlternateText = "envelope";
-				container.Controls.Add(contentImage);
+	```VB
+	Protected Sub Page_Init(sender As Object, e As EventArgs)
+		RadLinkButton1.ContentTemplate = New ButtonContentTemplate()
+	End Sub
 
-				Label contentLabel = new Label();
-				contentLabel.ID = "contentLabel";
-				contentLabel.Text = "E-Mail";
-				container.Controls.Add(contentLabel);
-			}
-		}
+	Public Class ButtonContentTemplate
+		Implements ITemplate
+		Private Sub ITemplate_InstantiateIn(container As Control) Implements ITemplate.InstantiateIn
+			Dim contentImage As New System.Web.UI.WebControls.Image()
+			contentImage.ID = "contentImage"
+			contentImage.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/envelope.png"
+			contentImage.AlternateText = "envelope"
+			container.Controls.Add(contentImage)
 
-	**VB**
-
-		Protected Sub Page_Init(sender As Object, e As EventArgs)
-			RadLinkButton1.ContentTemplate = New ButtonContentTemplate()
+			Dim contentLabel As New Label()
+			contentLabel.ID = "contentLabel"
+			contentLabel.Text = "E-Mail"
+			container.Controls.Add(contentLabel)
 		End Sub
-
-		Public Class ButtonContentTemplate
-			Implements ITemplate
-			Private Sub ITemplate_InstantiateIn(container As Control) Implements ITemplate.InstantiateIn
-				Dim contentImage As New System.Web.UI.WebControls.Image()
-				contentImage.ID = "contentImage"
-				contentImage.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/envelope.png"
-				contentImage.AlternateText = "envelope"
-				container.Controls.Add(contentImage)
-
-				Dim contentLabel As New Label()
-				contentLabel.ID = "contentLabel"
-				contentLabel.Text = "E-Mail"
-				container.Controls.Add(contentLabel)
-			End Sub
-		End Class
+	End Class
+	```
 
 
 ## See Also

--- a/controls/linkbutton/getting-started.md
+++ b/controls/linkbutton/getting-started.md
@@ -14,10 +14,10 @@ The following tutorial demonstrates how to set up a page with a **RadLinkButton*
 
 1. In the default page of a new ASP.NET AJAX-enabled Web Application add a **RadLinkButton** control:
 
-	**ASP.NET**	
-	
-		<telerik:RadLinkButton id="RadLinkButton1" runat="server" text="My Button">
-		</telerik:RadLinkButton>	
+	```ASP.NET
+	<telerik:RadLinkButton id="RadLinkButton1" runat="server" text="My Button">
+	</telerik:RadLinkButton>	
+	```
 
 	The **Text** property specifies the text displayed in the **RadLinkButton** control.
 
@@ -27,9 +27,10 @@ The following tutorial demonstrates how to set up a page with a **RadLinkButton*
 
 At the end your **RadLinkButton** declaration should look like that:
 
-**ASP.NET**
+```ASP.NET
 
 	<telerik:RadLinkButton ID="RadLinkButton1" Text="RadLinkButton" NavigateUrl="https://www.telerik.com" Target="_blank"></telerik:RadLinkButton>
+```
 
 ## See Also
 

--- a/controls/linkbutton/mobile-support/render-modes.md
+++ b/controls/linkbutton/mobile-support/render-modes.md
@@ -22,18 +22,18 @@ There are two ways to configure the rendering mode of the controls:
 
 * The **RenderMode property** in the markup or in the code-behind that can be used for a particular instance:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadLinkButton ID="RadLinkButton1" runat="server" RenderMode="Lightweight" NavigateUrl="https://www.telerik.com" Target="_blank">
+	</telerik:RadLinkButton>
+	```
 
-		<telerik:RadLinkButton ID="RadLinkButton1" runat="server" RenderMode="Lightweight" NavigateUrl="https://www.telerik.com" Target="_blank">
-		</telerik:RadLinkButton>
+	```C#
+	RadLinkButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	```
 
-	**C#**
-
-		RadLinkButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-
-	**VB**
-
-		RadLinkButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```VB
+	RadLinkButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```
 
 * A **global setting in the web.config** file that will affect the entire application, unless a concrete value is specified for a given control instance:
 

--- a/controls/map/client-side-programming.md
+++ b/controls/map/client-side-programming.md
@@ -22,18 +22,18 @@ There are two ways to get a reference to the Kendo Map widget in order to use it
 
 	>caption **Example 1:** Get the Kendo Map object through the get_kendoWidget method:
 
-	**JavaScript**
-
-		var radMapObject = $find("<%=RadMap1.ClientID %>"); //the standard script control object
-		var kendoMap = radMapObject.get_kendoWidget(); //the Kendo widget
+	```JavaScript
+	var radMapObject = $find("<%=RadMap1.ClientID %>"); //the standard script control object
+	var kendoMap = radMapObject.get_kendoWidget(); //the Kendo widget
+	```
 
 * Use the standard Kendo approach for getting the widget through the data-attributes of the DOM element:
 
 	>caption **Example 2:** Get the Kendo Map object through the data attribute of the DOM object:
 
-	**JavaScript**
-
-		var kendoMap = $telerik._kendo.jQuery("#<%=RadMap1.ClientID %>").data("kendoMap");//the jQuery selector must get the RadMap wrapping div element
+	```JavaScript
+	var kendoMap = $telerik._kendo.jQuery("#<%=RadMap1.ClientID %>").data("kendoMap");//the jQuery selector must get the RadMap wrapping div element
+	```
 
 >important As of the 2026 Q1 release, Kendo jQuery widget plugins and data are registered on `$telerik._kendo.jQuery` — a different jQuery instance from `$telerik.$`. If you use `$telerik.$` with `.data("kendoXxx")`, it will return `undefined`. Always use `$telerik._kendo.jQuery` when accessing the underlying Kendo widget via the `.data()` method. The recommended approach, however, is to use the `get_kendoWidget()` method shown above.
 

--- a/controls/menu/data-binding/overview.md
+++ b/controls/menu/data-binding/overview.md
@@ -47,12 +47,12 @@ Usually, you also want to do one or more of the following:
 
 1. If the data source contains fields that map to other properties of menu items or to [custom attributes]({%slug menu/radmenu-items/custom-attributes%}), use the **[ItemDataBound event]({%slug menu/server-side-programming/itemdatabound%})** to set those values:
 
-	**C#**
-	
-		protected void RadMenu1_ItemDataBound(object sender, Telerik.Web.UI.RadMenuEventArgs e) 
-		{ 
-			e.Item.ToolTip = "Read more about " + (string)DataBinder.Eval(e.Item.DataItem, "Text");
-		}
+	```C#
+	protected void RadMenu1_ItemDataBound(object sender, Telerik.Web.UI.RadMenuEventArgs e) 
+	{ 
+		e.Item.ToolTip = "Read more about " + (string)DataBinder.Eval(e.Item.DataItem, "Text");
+	}
+	```
 		
 	**VB.NET**
 	

--- a/controls/multicolumncombobox/client-side-programming/overview.md
+++ b/controls/multicolumncombobox/client-side-programming/overview.md
@@ -22,16 +22,16 @@ RadMultiColumnComboBox is a server-side wrapper over the Kendo UI MultiColumnCom
 
 * Use the `get_kendoWidget()` method of the MS AJAX wrapper:
 
-    **JavaScript**
-    
-        var rmccbObject  = $find("<%=RadMultiColumnComboBox1.ClientID %>"); //the standard script control object
-        var kendoMccbm = rmccbObject.get_kendoWidget(); //the Kendo widget
+    ```JavaScript
+    var rmccbObject  = $find("<%=RadMultiColumnComboBox1.ClientID %>"); //the standard script control object
+    var kendoMccbm = rmccbObject.get_kendoWidget(); //the Kendo widget
+    ```
 
 * Get the Kendo Widget in its usual way. Make sure to use the `$telerik._kendo.jQuery` reference that has the Kendo widget data:
 
-    **JavaScript**
-    
-        var kendoMccbm = $telerik._kendo.jQuery("#<%=RadMultiColumnComboBox1.ClientID %>").data("kendoMultiColumnComboBox"); //the jQuery selector must get the RadMultiColumnComboBox1 wrapper span element
+    ```JavaScript
+    var kendoMccbm = $telerik._kendo.jQuery("#<%=RadMultiColumnComboBox1.ClientID %>").data("kendoMultiColumnComboBox"); //the jQuery selector must get the RadMultiColumnComboBox1 wrapper span element
+    ```
 
 >important As of the 2026 Q1 release, Kendo jQuery widget plugins and data are registered on `$telerik._kendo.jQuery` — a different jQuery instance from `$telerik.$`. If you use `$telerik.$` with `.data("kendoXxx")`, it will return `undefined`. Always use `$telerik._kendo.jQuery` when accessing the underlying Kendo widget via the `.data()` method. The recommended approach, however, is to use the `get_kendoWidget()` method shown above.
 

--- a/controls/multiselect/client-side-programming/overview.md
+++ b/controls/multiselect/client-side-programming/overview.md
@@ -22,16 +22,16 @@ RadMultiSelect is a server-side wrapper over the Kendo UI MultiSelect Widget. Th
 
 * Use the `get_kendoWidget()` method of the MS AJAX wrapper:
 
-    **JavaScript**
-    
-        var multiSelectObject  = $find("<%=RadMultiSelect1.ClientID %>"); //the standard script control object
-        var kendoMultiSelect = multiSelectObject.get_kendoWidget(); //the Kendo widget
+    ```JavaScript
+    var multiSelectObject  = $find("<%=RadMultiSelect1.ClientID %>"); //the standard script control object
+    var kendoMultiSelect = multiSelectObject.get_kendoWidget(); //the Kendo widget
+    ```
 
 * Get the Kendo Widget in its usual way. Make sure to use the `$telerik._kendo.jQuery` reference that has the Kendo widget data:
 
-    **JavaScript**
-    
-        var kendoMultiSelect = $telerik._kendo.jQuery("#<%=RadMultiSelect1.ClientID %>").data("kendoMultiSelect"); //the jQuery selector must get the RadMultiSelect1 wrapper span element
+    ```JavaScript
+    var kendoMultiSelect = $telerik._kendo.jQuery("#<%=RadMultiSelect1.ClientID %>").data("kendoMultiSelect"); //the jQuery selector must get the RadMultiSelect1 wrapper span element
+    ```
 
 >important As of the 2026 Q1 release, Kendo jQuery widget plugins and data are registered on `$telerik._kendo.jQuery` — a different jQuery instance from `$telerik.$`. If you use `$telerik.$` with `.data("kendoXxx")`, it will return `undefined`. Always use `$telerik._kendo.jQuery` when accessing the underlying Kendo widget via the `.data()` method. The recommended approach, however, is to use the `get_kendoWidget()` method shown above.
 

--- a/controls/pdfviewer/client-side-programming/overview.md
+++ b/controls/pdfviewer/client-side-programming/overview.md
@@ -22,16 +22,16 @@ RadPdfViewer is a server-side wrapper over the Kendo UI PdfViewer Widget. Thus, 
 
 * Use the `get_kendoWidget()` method of the MS AJAX wrapper:
 
-    **JavaScript**
-    
-        var pdfViewerObject  = $find("<%=RadPdfViewer1.ClientID %>"); //the standard script control object
-        var kendoPdfViewerObject = pdfViewerObject.get_kendoWidget(); //the Kendo widget
+    ```JavaScript
+    var pdfViewerObject  = $find("<%=RadPdfViewer1.ClientID %>"); //the standard script control object
+    var kendoPdfViewerObject = pdfViewerObject.get_kendoWidget(); //the Kendo widget
+    ```
 
 * Get the Kendo Widget in its usual way. Make sure to use the `$telerik._kendo.jQuery` reference that has the Kendo widget data:
 
-    **JavaScript**
-    
-        var kendoPdfViewer = $telerik._kendo.jQuery("#<%=RadPdfViewer1.ClientID %>").data("kendoPDFViewer"); //the jQuery selector must get the RadPdfViewer1 wrapper span element
+    ```JavaScript
+    var kendoPdfViewer = $telerik._kendo.jQuery("#<%=RadPdfViewer1.ClientID %>").data("kendoPDFViewer"); //the jQuery selector must get the RadPdfViewer1 wrapper span element
+    ```
 
 >important As of the 2026 Q1 release, Kendo jQuery widget plugins and data are registered on `$telerik._kendo.jQuery` — a different jQuery instance from `$telerik.$`. If you use `$telerik.$` with `.data("kendoXxx")`, it will return `undefined`. Always use `$telerik._kendo.jQuery` when accessing the underlying Kendo widget via the `.data()` method. The recommended approach, however, is to use the `get_kendoWidget()` method shown above.
 

--- a/controls/pdfviewer/getting-started.md
+++ b/controls/pdfviewer/getting-started.md
@@ -20,13 +20,13 @@ The following tutorial demonstrates how you can add a **RadPdfViewer** control p
 
 2. Register the Pdf.js library on the page:  
 
-    **JavaScript**
-    
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.2.2/pdf.js"></script>
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.2.2/pdf.worker.js"></script>
-        <script type="text/javascript">
-            window.pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.2.2/pdf.worker.js';
-        </script>
+    ```JavaScript
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.2.2/pdf.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.2.2/pdf.worker.js"></script>
+    <script type="text/javascript">
+        window.pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.2.2/pdf.worker.js';
+    </script>
+    ```
 
 3. Add a **RadPdfViewer** control to the page, and set its properties:
 

--- a/controls/pushbutton/appearance-and-styling/create-a-custom-skin.md
+++ b/controls/pushbutton/appearance-and-styling/create-a-custom-skin.md
@@ -40,15 +40,15 @@ The second file represents the actual skin of the control, and its name consists
 
 1. Add a new server declaration of **RadPushButton** on your page, and set **Skin="MyCustomSkin"** and **EnableEmbeddedSkins="false"**:
 
-	**ASP.NET**
-
-		<telerik:RadPushButton ID="RadPushButton1" runat="server" EnableEmbeddedSkins="false" Skin="MyCustomSkin" />
+	```ASP.NET
+	<telerik:RadPushButton ID="RadPushButton1" runat="server" EnableEmbeddedSkins="false" Skin="MyCustomSkin" />
+	```
 
 1. Register **Button.MyCustomSkin.css** in the head section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 
-	**ASP.NET**
-
-		<link href="Skins/MyCustomSkin/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+	```ASP.NET
+	<link href="Skins/MyCustomSkin/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+	```
 
 1. Make sure the path to the files is correct; otherwise the skin will not apply;
 

--- a/controls/pushbutton/functionality/Icons/custom-icons.md
+++ b/controls/pushbutton/functionality/Icons/custom-icons.md
@@ -56,25 +56,25 @@ You can use custom font icons in **RadPushButton** as well. To do that, follow t
 
 1. Load the stylesheet with the desired font icons on the page.
 
-	**CSS**
-
-		<link rel="stylesheet" href="myCustomFontStyleSheet.css" />
+	```CSS
+	<link rel="stylesheet" href="myCustomFontStyleSheet.css" />
+	```
 
 1. Override the font-family of the button's icon element with the target one (see **Example 3**).
 
-	**CSS**
-
-		button.RadButton .rbIcon:before {
-			font-family: myCustomFont;
-		}
+	```CSS
+	button.RadButton .rbIcon:before {
+		font-family: myCustomFont;
+	}
+	```
 
 1. Set the custom font icon class to the **Icon.CssClass** property.
 
-	**ASP.NET**
-
-		<telerik:RadPushButton ID="RadButton1" runat="server" Text="Button With Custom Font Icon">
-			<Icon CssClass="myCustomFontIconClass" />
-		</telerik:RadPushButton>
+	```ASP.NET
+	<telerik:RadPushButton ID="RadButton1" runat="server" Text="Button With Custom Font Icon">
+		<Icon CssClass="myCustomFontIconClass" />
+	</telerik:RadPushButton>
+	```
 
 You can find below an example with [Font Awesome Icons](https://github.com/FortAwesome/Font-Awesome).
 

--- a/controls/pushbutton/functionality/contenttemplate.md
+++ b/controls/pushbutton/functionality/contenttemplate.md
@@ -44,95 +44,95 @@ You can add controls to **RadPushButton** from the code-behind in two ways:
 
 	**Example 2**: Adding controls to the **Controls** collection of **RadPushButton** from the code-behind.
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadPushButton runat="server" ID="RadPushButton1" Width="160px" Height="85px">
+	</telerik:RadPushButton>
+	```
 
-		<telerik:RadPushButton runat="server" ID="RadPushButton1" Width="160px" Height="85px">
-		</telerik:RadPushButton>
-
-	**C#**
-
-		protected void Page_Init(object sender, EventArgs e)
+	```C#
+	protected void Page_Init(object sender, EventArgs e)
+	{
+		Image buttonContentImage = new Image()
 		{
-			Image buttonContentImage = new Image()
-			{
-				ID = "buttonContent",
-				AlternateText = "my car",
-				ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/car.png"
-			};
-			Label buttonContentLabel = new Label() { ID = "Label1", Text = "Vehicles" };
-			RadPushButton1.Controls.Add(buttonContentImage);
-			RadPushButton1.Controls.Add(buttonContentLabel);
-		}
-	**VB**
-
-		Protected Sub Page_Init(sender As Object, e As EventArgs) Handles Me.Init
-			Dim buttonContentImage As New Image() With {
-				.ID = "buttonContent",
-				.AlternateText = "my car",
-				.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/car.png"
+			ID = "buttonContent",
+			AlternateText = "my car",
+			ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/car.png"
+		};
+		Label buttonContentLabel = new Label() { ID = "Label1", Text = "Vehicles" };
+		RadPushButton1.Controls.Add(buttonContentImage);
+		RadPushButton1.Controls.Add(buttonContentLabel);
+	}
+	```
+	```VB
+	Protected Sub Page_Init(sender As Object, e As EventArgs) Handles Me.Init
+		Dim buttonContentImage As New Image() With {
+			.ID = "buttonContent",
+			.AlternateText = "my car",
+			.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/car.png"
 			}
-			Dim buttonContentLabel As New Label() With {
-			   .ID = "Label1",
-			   .Text = "Vehicles"
+		Dim buttonContentLabel As New Label() With {
+		   .ID = "Label1",
+		   .Text = "Vehicles"
 			}
-			RadPushButton1.Controls.Add(buttonContentImage)
-			RadPushButton1.Controls.Add(buttonContentLabel)
-		End Sub
+		RadPushButton1.Controls.Add(buttonContentImage)
+		RadPushButton1.Controls.Add(buttonContentLabel)
+	End Sub
+	```
 
 * Set the **ContentTemplate** property to an instance of a class that implements the **ITemplate** interface (**Example 3**).
 
 	**Example 3**: Adding controls to the **RadPushButton** by using the **ITemplate** class.
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadPushButton runat="server" ID="RadPushButton1" Width="71px" Height="70px">
+	</telerik:RadPushButton>
+	```
 
-		<telerik:RadPushButton runat="server" ID="RadPushButton1" Width="71px" Height="70px">
-		</telerik:RadPushButton>
+	```C#
+	protected void Page_Init(object sender, EventArgs e)
+	{
+		RadPushButton1.ContentTemplate = new ButtonContentTemplate();
+	}
 
-	**C#**
-
-		protected void Page_Init(object sender, EventArgs e)
+	public class ButtonContentTemplate : ITemplate
+	{
+		void ITemplate.InstantiateIn(Control container)
 		{
-			RadPushButton1.ContentTemplate = new ButtonContentTemplate();
+			System.Web.UI.WebControls.Image contentImage = new System.Web.UI.WebControls.Image();
+			contentImage.ID = "contentImage";
+			contentImage.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/envelope.png";
+			contentImage.AlternateText = "envelope";
+			container.Controls.Add(contentImage);
+
+			Label contentLabel = new Label();
+			contentLabel.ID = "contentLabel";
+			contentLabel.Text = "E-Mail";
+			container.Controls.Add(contentLabel);
 		}
+	}
+	```
 
-		public class ButtonContentTemplate : ITemplate
-		{
-			void ITemplate.InstantiateIn(Control container)
-			{
-				System.Web.UI.WebControls.Image contentImage = new System.Web.UI.WebControls.Image();
-				contentImage.ID = "contentImage";
-				contentImage.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/envelope.png";
-				contentImage.AlternateText = "envelope";
-				container.Controls.Add(contentImage);
+	```VB
+	Protected Sub Page_Init(sender As Object, e As EventArgs)
+		RadPushButton1.ContentTemplate = New ButtonContentTemplate()
+	End Sub
 
-				Label contentLabel = new Label();
-				contentLabel.ID = "contentLabel";
-				contentLabel.Text = "E-Mail";
-				container.Controls.Add(contentLabel);
-			}
-		}
+	Public Class ButtonContentTemplate
+		Implements ITemplate
+		Private Sub ITemplate_InstantiateIn(container As Control) Implements ITemplate.InstantiateIn
+			Dim contentImage As New System.Web.UI.WebControls.Image()
+			contentImage.ID = "contentImage"
+			contentImage.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/envelope.png"
+			contentImage.AlternateText = "envelope"
+			container.Controls.Add(contentImage)
 
-	**VB**
-
-		Protected Sub Page_Init(sender As Object, e As EventArgs)
-			RadPushButton1.ContentTemplate = New ButtonContentTemplate()
+			Dim contentLabel As New Label()
+			contentLabel.ID = "contentLabel"
+			contentLabel.Text = "E-Mail"
+			container.Controls.Add(contentLabel)
 		End Sub
-
-		Public Class ButtonContentTemplate
-			Implements ITemplate
-			Private Sub ITemplate_InstantiateIn(container As Control) Implements ITemplate.InstantiateIn
-				Dim contentImage As New System.Web.UI.WebControls.Image()
-				contentImage.ID = "contentImage"
-				contentImage.ImageUrl = "https://demos.telerik.com/aspnet-ajax/button/examples/contenttemplate/Images/envelope.png"
-				contentImage.AlternateText = "envelope"
-				container.Controls.Add(contentImage)
-
-				Dim contentLabel As New Label()
-				contentLabel.ID = "contentLabel"
-				contentLabel.Text = "E-Mail"
-				container.Controls.Add(contentLabel)
-			End Sub
-		End Class
+	End Class
+	```
 
 
 ## See Also

--- a/controls/pushbutton/getting-started.md
+++ b/controls/pushbutton/getting-started.md
@@ -14,25 +14,25 @@ The following tutorial demonstrates how to set up a page with a **RadPushButton*
 
 1. In the default page of a new ASP.NET AJAX-enabled Web Application add a **RadPushButton** control:
 
-	**ASP.NET**	
-	
-		<telerik:RadPushButton id="RadPushButton1" runat="server" text="My Button">
-		</telerik:RadPushButton>	
+	```ASP.NET
+	<telerik:RadPushButton id="RadPushButton1" runat="server" text="My Button">
+	</telerik:RadPushButton>	
+	```
 
 	The **Text** property specifies the text displayed in the **RadPushButton** control.
 
 1. To hook to the **OnClick** server-side event of **RadPushButton** switch to [Design view]({%slug pushbutton/design-time%}) of Visual Studio and double click on the button. This operation will insert the following function in the code behind file:
 
-	**C#**
-	
-		protected void RadPushButton1_Click(object sender, EventArgs e)
-		{
-		}
+	```C#
+	protected void RadPushButton1_Click(object sender, EventArgs e)
+	{
+	}
+	```
 
-	**VB**
-	
-		Protected Sub RadPushButton1_Click(ByVal sender As Object, ByVal e As EventArgs)
-		End Sub
+	```VB
+	Protected Sub RadPushButton1_Click(ByVal sender As Object, ByVal e As EventArgs)
+	End Sub
+	```
 
 	as well as add `OnClick="RadPushButton1_Click"` to the **RadPushButton**'s declaration. In the Click event handler add the code that you want to be executed when the **RadPushButton** control is clicked.
 

--- a/controls/pushbutton/mobile-support/render-modes.md
+++ b/controls/pushbutton/mobile-support/render-modes.md
@@ -22,19 +22,19 @@ There are two ways to configure the rendering mode of the controls:
 
 * The **RenderMode property** in the markup or in the code-behind that can be used for a particular instance:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadPushButton ID="RadPushButton1" runat="server" RenderMode="Lightweight">
+	</telerik:RadPushButton>
+	```
 
-		<telerik:RadPushButton ID="RadPushButton1" runat="server" RenderMode="Lightweight">
-		</telerik:RadPushButton>
 
+	```C#
+	RadPushButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	```
 
-	**C#**
-
-		RadPushButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-
-	**VB**
-
-		RadPushButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```VB
+	RadPushButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```
 
 
 * A **global setting in the web.config** file that will affect the entire application, unless a concrete value is specified for a given control instance:

--- a/controls/radiobuttonlist/appearance-and-styling/create-a-custom-skin.md
+++ b/controls/radiobuttonlist/appearance-and-styling/create-a-custom-skin.md
@@ -40,16 +40,16 @@ The second file represents the actual skin of the control, and its name consists
 
 1. Add a new server declaration of **RadRadioButtonList** on your page and set **Skin="MyCustomSkin"** and **EnableEmbeddedSkins="false"**:
 
-	**ASP.NET**
-
-		<telerik:RadRadioButtonList runat="server" ID="RadRadioButtonList1" Skin="MyCustomSkin" EnableEmbeddedSkins="false">
-		</telerik:RadRadioButtonList>
+	```ASP.NET
+	<telerik:RadRadioButtonList runat="server" ID="RadRadioButtonList1" Skin="MyCustomSkin" EnableEmbeddedSkins="false">
+	</telerik:RadRadioButtonList>
+	```
 
 1. Register **Button.MyCustomSkin.css** in the head section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 
-	**ASP.NET**
-
-		<link href="Skins/MyCustomSkinLite/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+	```ASP.NET
+	<link href="Skins/MyCustomSkinLite/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+	```
 
 1. Make sure the path to the files is correct; otherwise the skin will not apply;
 

--- a/controls/radiobuttonlist/functionality/standalone-radiobutton.md
+++ b/controls/radiobuttonlist/functionality/standalone-radiobutton.md
@@ -29,55 +29,55 @@ These steps illustrate how to include a single **RadRadioButton**, handle the cl
 
 1. In the default page of a new ASP.NET AJAX-enabled Web Application, add a **RadRadioButton** control:
 	
-	**ASP.NET**
-
-		<telerik:RadRadioButton runat="server" ID="RadioButton1" />
+    ```ASP.NET
+    <telerik:RadRadioButton runat="server" ID="RadioButton1" />
+    ```
 
 1. Set the `Text` and `Value` properties to some desired values:
 
-	**ASP.NET**
-
-		<telerik:RadRadioButton runat="server" ID="RadioButton1" Value="radio" Text="Radio Button" />
+    ```ASP.NET
+    <telerik:RadRadioButton runat="server" ID="RadioButton1" Value="radio" Text="Radio Button" />
+    ```
 
 1. To handle the client-side `clicking` event, assign a JavaScript function to the `OnClientClicking` property:
 
-	**ASP.NET**
-
-		<telerik:RadRadioButton runat="server" ID="RadioButton1" Value="radio" Text="Radio Button" 
-			OnClientClicking="OnClientClicking" />
-		
-		<script>
-			function OnClientClicking(sender, args) {
-				args.set_cancel(!confirm("Are you sure?"));
-			}
-		</script>
+    ```ASP.NET
+    <telerik:RadRadioButton runat="server" ID="RadioButton1" Value="radio" Text="Radio Button" 
+        OnClientClicking="OnClientClicking" />
+	
+    <script>
+        function OnClientClicking(sender, args) {
+            args.set_cancel(!confirm("Are you sure?"));
+        }
+    </script>
+    ```
 
 1. To handle the server-side `CheckedChange` event, assign a server-side function to the `OnCheckedChanged` property:
 
-	**ASP.NET**
+    ```ASP.NET
+    <telerik:RadRadioButton runat="server" ID="RadioButton1" Value="radio" Text="Radio Button" 
+        OnClientClicking="OnClientClicking"
+        OnCheckedChanged="RadioButton1_CheckedChanged" />
+	
+    <script>
+        function OnClientClicking(sender, args) {
+            args.set_cancel(!confirm("Are you sure?"));
+        }
+    </script>
+    ```
 
-		<telerik:RadRadioButton runat="server" ID="RadioButton1" Value="radio" Text="Radio Button" 
-			OnClientClicking="OnClientClicking"
-			OnCheckedChanged="RadioButton1_CheckedChanged" />
-		
-		<script>
-			function OnClientClicking(sender, args) {
-				args.set_cancel(!confirm("Are you sure?"));
-			}
-		</script>
+    ```C#
+    protected void RadioButton1_CheckedChanged(object sender, EventArgs e)
+    {
+        Response.Write("You selected this Radio Button");
+    }
+    ```
 
-	**C#**
-
-		protected void RadioButton1_CheckedChanged(object sender, EventArgs e)
-		{
-			Response.Write("You selected this Radio Button");
-		}
-
-	**VB**
-
-		Protected Sub RadioButton1_CheckedChanged(ByVal sender As Object, ByVal e As EventArgs)
-			Response.Write("You selected this Radio Button")
-		End Sub
+    ```VB
+    Protected Sub RadioButton1_CheckedChanged(ByVal sender As Object, ByVal e As EventArgs)
+        Response.Write("You selected this Radio Button")
+    End Sub
+    ```
 
 ## Programming
 

--- a/controls/radiobuttonlist/getting-started.md
+++ b/controls/radiobuttonlist/getting-started.md
@@ -14,39 +14,39 @@ The following help article demonstrates how to set up a page with a **RadRadioBu
 
 1. In the default page of a new ASP.NET AJAX-enabled Web Application, add a **RadRadioButtonList** control:
 
-	**ASP.NET**	
-	
-		<telerik:RadRadioButtonList ID="RadRadioButtonList1" runat="server">
-		</telerik:RadRadioButtonList>
+	```ASP.NET
+	<telerik:RadRadioButtonList ID="RadRadioButtonList1" runat="server">
+	</telerik:RadRadioButtonList>
+	```
 
 1. Add two `RadioButtonListItem` objects to the `Items` collection and set the appropriate values for `Text` and `Selected` properties of each item:
 
-	**ASP.NET**
-
-		<telerik:RadRadioButtonList ID="RadRadioButtonList1" runat="server">
-			<Items>
-				<telerik:RadioButtonListItem Text="Accept" Value="0" Selected="true" />
-				<telerik:RadioButtonListItem Text="Decline" Value="1" />
-			</Items>
-		</telerik:RadRadioButtonList>
+	```ASP.NET
+	<telerik:RadRadioButtonList ID="RadRadioButtonList1" runat="server">
+		<Items>
+			<telerik:RadioButtonListItem Text="Accept" Value="0" Selected="true" />
+			<telerik:RadioButtonListItem Text="Decline" Value="1" />
+		</Items>
+	</telerik:RadRadioButtonList>
+	```
 
 1. To hook to the **OnSelectedIndexChanged** server-side event of **RadRadioButtonList**, add an attribute to the main control tag and add the method signature:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadRadioButtonList ID="RadRadioButtonList1" runat="server" OnSelectedIndexChanged="RadRadioButtonList1_SelectedIndexChanged">
+		<Items>
+			<telerik:RadioButtonListItem Text="Accept" Value="0" Selected="true" />
+			<telerik:RadioButtonListItem Text="Decline" Value="1" />
+		</Items>
+	</telerik:RadRadioButtonList>
+	```
 
-		<telerik:RadRadioButtonList ID="RadRadioButtonList1" runat="server" OnSelectedIndexChanged="RadRadioButtonList1_SelectedIndexChanged">
-			<Items>
-				<telerik:RadioButtonListItem Text="Accept" Value="0" Selected="true" />
-				<telerik:RadioButtonListItem Text="Decline" Value="1" />
-			</Items>
-		</telerik:RadRadioButtonList>
+	```C#
+	protected void RadRadioButtonList1_SelectedIndexChanged(object sender, EventArgs e)
+	{
 
-	**C#**
-	
-		protected void RadRadioButtonList1_SelectedIndexChanged(object sender, EventArgs e)
-		{
-
-		}
+	}
+	```
 
 	**VB.NET**
 	
@@ -55,23 +55,23 @@ The following help article demonstrates how to set up a page with a **RadRadioBu
 
 1. Add a Label control to write the information to:
 
-	**ASP.NET**
-
-		<asp:Label ID="Label1" Text="" runat="server" />
+	```ASP.NET
+	<asp:Label ID="Label1" Text="" runat="server" />
+	```
 
 1. Use the **OnSelectedIndexChanged** event handler to write information about the properties of the `SelectedItem` of the `RadRadioButtonList`:
 
-	**C#**
-	
-		protected void RadRadioButtonList1_SelectedIndexChanged(object sender, EventArgs e)
-		{
-			RadRadioButtonList radioButtonList = sender as RadRadioButtonList;
+	```C#
+	protected void RadRadioButtonList1_SelectedIndexChanged(object sender, EventArgs e)
+	{
+		RadRadioButtonList radioButtonList = sender as RadRadioButtonList;
 
 
-			string data = string.Format("selected index: {0}, selected value {1}, selected text: {2}",
-										radioButtonList.SelectedIndex, radioButtonList.SelectedValue, radioButtonList.SelectedItem.Text);
-			Label1.Text = data;
-		}
+		string data = string.Format("selected index: {0}, selected value {1}, selected text: {2}",
+									radioButtonList.SelectedIndex, radioButtonList.SelectedValue, radioButtonList.SelectedItem.Text);
+		Label1.Text = data;
+	}
+	```
 
 	**VB.NET**
 	

--- a/controls/radiobuttonlist/mobile-support/render-modes.md
+++ b/controls/radiobuttonlist/mobile-support/render-modes.md
@@ -21,24 +21,24 @@ There are two ways to configure the rendering mode of the controls:
 
 * The **RenderMode property** in the markup or in the code-behind that can be used for a particular instance:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadRadioButtonList ID="RadRadioButtonList1" runat="server" RenderMode="Lightweight">
+		<Items>
+			<telerik:RadioButtonListItem Text="English" Selected="true" />
+			<telerik:RadioButtonListItem Text="German" />
+			<telerik:RadioButtonListItem Text="French" />
+		</Items>
+	</telerik:RadRadioButtonList>
+	```
 
-		<telerik:RadRadioButtonList ID="RadRadioButtonList1" runat="server" RenderMode="Lightweight">
-			<Items>
-				<telerik:RadioButtonListItem Text="English" Selected="true" />
-				<telerik:RadioButtonListItem Text="German" />
-				<telerik:RadioButtonListItem Text="French" />
-			</Items>
-		</telerik:RadRadioButtonList>
 
+	```C#
+	RadRadioButtonList1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	```
 
-	**C#**
-
-		RadRadioButtonList1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-
-	**VB**
-
-		RadRadioButtonList1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```VB
+	RadRadioButtonList1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```
 
 
 * A **global setting in the web.config** file that will affect the entire application, unless a concrete value is specified for a given control instance:

--- a/controls/rating/appearance-and-styling/create-a-custom-skin.md
+++ b/controls/rating/appearance-and-styling/create-a-custom-skin.md
@@ -44,14 +44,14 @@ In order to explain better the CSS classes of RadRating, we will use both **Rati
 
 1. Add a new server declaration of RadRating on your page, and set Skin="MyCustomSkin", EnableEmbeddedSkins="false" and EnableEmbeddedBasestylesheet="false":
 
-	**ASP.NET**
-
-		<telerik:RadRating RenderMode="Lightweight" 
-			ID="RadRating1" 
-			runat="server" 
-			Skin="MyCustomSkin" 
-			EnableEmbeddedSkins="false"
-			EnableEmbeddedBaseStylesheet="false" />
+	```ASP.NET
+	<telerik:RadRating RenderMode="Lightweight" 
+		ID="RadRating1" 
+		runat="server" 
+		Skin="MyCustomSkin" 
+		EnableEmbeddedSkins="false"
+		EnableEmbeddedBaseStylesheet="false" />
+	```
 
 1. Register **Rating.css** and **Rating.MyCustomSkin.css** in the <head>...</head> section of your webpage. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:(Make sure the paths to the files are correct; otherwise the skin will not apply correctly)
 

--- a/controls/rating/mobile-support/render-modes.md
+++ b/controls/rating/mobile-support/render-modes.md
@@ -28,26 +28,26 @@ There are two ways to configure the rendering mode of the controls:
 
 * The **RenderMode property** in the markup or in the code-behind that can be used for a particular instance:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadRating id="RadRating1" runat="server" RenderMode="Lightweight">
+	</telerik:RadRating>
+	```
 
-		<telerik:RadRating id="RadRating1" runat="server" RenderMode="Lightweight">
-		</telerik:RadRating>
+	```C#
+	RadRating1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	```
 
-	**C#**
-
-		RadRating1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-
-	**VB**
-
-		RadRating1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```VB
+	RadRating1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```
 
 * A global setting in the **web.config** file that will affect the entire application, unless a concrete value is specified for a given control instance:
 
-	**XML**
-
-		<appSettings>
-			<add key="Telerik.Web.UI.Rating.RenderMode" value="lightweight" />
-		</appSettings>
+	```XML
+	<appSettings>
+		<add key="Telerik.Web.UI.Rating.RenderMode" value="lightweight" />
+	</appSettings>
+	```
 
 # See Also
 

--- a/controls/rotator/appearance-and-styling/create-a-custom-skin-from-an-existing-one.md
+++ b/controls/rotator/appearance-and-styling/create-a-custom-skin-from-an-existing-one.md
@@ -40,18 +40,18 @@ In order to explain better the CSS classes of RadRotator, we will use both Rotat
 
 1. Put a new server declaration of RadRotator on your page, and set **Skin="MyCustomSkin", EnableEmbeddedSkins="false"** and **EnableEmbeddedBasestylesheet="false"**:
 
-	**ASP.NET**
-
-		<telerik:RadRotator RenderMode="Lightweight" ID="RadRotator1" runat="server" Skin="MyCustomSkin" EnableEmbeddedSkins="false"
-			EnableEmbeddedBaseStylesheet="false">
-		</telerik:RadRotator>
+	```ASP.NET
+	<telerik:RadRotator RenderMode="Lightweight" ID="RadRotator1" runat="server" Skin="MyCustomSkin" EnableEmbeddedSkins="false"
+		EnableEmbeddedBaseStylesheet="false">
+	</telerik:RadRotator>
+	```
 
 1. Register Rotator.css and Rotator.MyCustomSkin.css in the <head>...</head> section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 
-	**ASP.NET**
-
-		<link rel="stylesheet" type="text/css" href="Skins/Rotator.css"></link>
-		<link rel="stylesheet" type="text/css" href="Skins/MyCustomSkin/Rotator.MyCustomSkin.css"></link>
+	```ASP.NET
+	<link rel="stylesheet" type="text/css" href="Skins/Rotator.css"></link>
+	<link rel="stylesheet" type="text/css" href="Skins/MyCustomSkin/Rotator.MyCustomSkin.css"></link>
+	```
 
 	Make sure the path to the files is correct, otherwise the skin will not apply.
 

--- a/controls/rotator/functionality/adrotator.md
+++ b/controls/rotator/functionality/adrotator.md
@@ -56,17 +56,17 @@ In some scenarios you might want to have direct control on which images are sele
 
 	1. Register the class you added on the page that you will use the custom RadRotator:
 
-		**ASP.NET**
-
-			<%@ Register Namespace="CustomWebControls" TagPrefix="webControls" %>
+		```ASP.NET
+		<%@ Register Namespace="CustomWebControls" TagPrefix="webControls" %>
+		```
 
 	1. Add an instance of the custom control:
 
-		**ASP.NET**
-		
-			<webControls:CustomRotator runat="server" ID="RadRotator1" Width="320px" ItemWidth="160px"
-				Height="120px" ItemHeight="113px" BannersPath="~/Images">
-			</webControls:CustomRotator>
+		```ASP.NET
+		<webControls:CustomRotator runat="server" ID="RadRotator1" Width="320px" ItemWidth="160px"
+			Height="120px" ItemHeight="113px" BannersPath="~/Images">
+		</webControls:CustomRotator>
+		```
 		
 >caption **Example 1**: Override the RadRotator's GetBanners method.
 
@@ -196,24 +196,24 @@ This tutorial shows how to create a simple web application with RadRotator that 
 
 1. Set the **BannersPath** property of the rotator to **“~/Images”**. The mark-up should look like the following:
 
-	**ASP.NET**
-
-		<telerik:RadRotator RenderMode="Lightweight" ID="RadRotator1" runat="server"
-			Width="600px" Height="300px" ItemWidth="300px" ItemHeight="300px"
-			BannersPath="~/Images">
-		</telerik:RadRotator> 
+	```ASP.NET
+	<telerik:RadRotator RenderMode="Lightweight" ID="RadRotator1" runat="server"
+		Width="600px" Height="300px" ItemWidth="300px" ItemHeight="300px"
+		BannersPath="~/Images">
+	</telerik:RadRotator> 
+	```
 
 1. View the page in the browser, and the Rotator will start animating through the images instantly.
 
 1. In case the images have different width and height than the ones of the RotatorItem, you can easily fix this by placing the following CSS code in the head tag of your page. Note that you must set the CssClass property of the Rotator to RotatorImages. Here is the code:
 
-	**ASP.NET**
-
-		<style type="text/css">
-			.RotatorImages .rrBanner
-			{
-				width: 300px;
-				height: 300px;
-			}
-		</style>
+	```ASP.NET
+	<style type="text/css">
+		.RotatorImages .rrBanner
+		{
+			width: 300px;
+			height: 300px;
+		}
+	</style>
+	```
 

--- a/controls/scheduler/customizing-the-advanced-form/using-the-advanced-templates.md
+++ b/controls/scheduler/customizing-the-advanced-form/using-the-advanced-templates.md
@@ -52,52 +52,52 @@ The advanced form looks like this:
 
 2. In **AdvancedForm**.**ascx** add the following code right above the Custom Attributes panel:
 
-	**ASP.NET**
-		
-		<label>Color: </label>
-		<telerik:RadColorPicker RenderMode="Lightweight" ID="AppointmentColorPicker" CssClass="rsAdvResourceValue" NoColorText="transparent" ShowIcon="true" PaletteModes="HSV"
-		   runat="server">
-		</telerik:RadColorPicker>     	
+	```ASP.NET
+	<label>Color: </label>
+	<telerik:RadColorPicker RenderMode="Lightweight" ID="AppointmentColorPicker" CssClass="rsAdvResourceValue" NoColorText="transparent" ShowIcon="true" PaletteModes="HSV"
+	   runat="server">
+	</telerik:RadColorPicker>     	
+	```
 		
 	
 3. Expose an **AppointmentColor** property using the RadColorpicker control added in step 2 above.
 
 	In code behind of **AdvancedForm**.ascx add the following code in the "Attributes and resources" region:
 
-	**C#**
-	
-		// Attributes and resources
-		[Bindable(BindableSupport.Yes, BindingDirection.TwoWay)]
-		public string AppointmentColor
+	```C#
+	// Attributes and resources
+	[Bindable(BindableSupport.Yes, BindingDirection.TwoWay)]
+	public string AppointmentColor
+	{
+		get
 		{
-			get
-			{
-				return AppointmentColorPicker.SelectedColor.ToArgb().ToString();
-			}
-			set
-			{
-				int argbValue;
-				if (int.TryParse(value, out argbValue))
-					AppointmentColorPicker.SelectedColor = Color.FromArgb(argbValue);
-			}
-		} 
+			return AppointmentColorPicker.SelectedColor.ToArgb().ToString();
+		}
+		set
+		{
+			int argbValue;
+			if (int.TryParse(value, out argbValue))
+				AppointmentColorPicker.SelectedColor = Color.FromArgb(argbValue);
+		}
+	} 
+	```
 	
-	**VB**
-	
-		' Attributes and resources
+	```VB
+	' Attributes and resources
 
-		<Bindable(BindableSupport.Yes, BindingDirection.TwoWay)> _
-		Public Property AppointmentColor() As String
-			Get
-				Return AppointmentColorPicker.SelectedColor.ToArgb().ToString()
-			End Get
-			Set(ByVal value As String)
-				Dim argbValue As Integer
-				If Integer.TryParse(value, argbValue) Then
-					AppointmentColorPicker.SelectedColor = Color.FromArgb(argbValue)
-				End If
-			End Set
-		End Property
+	<Bindable(BindableSupport.Yes, BindingDirection.TwoWay)> _
+	Public Property AppointmentColor() As String
+		Get
+			Return AppointmentColorPicker.SelectedColor.ToArgb().ToString()
+		End Get
+		Set(ByVal value As String)
+			Dim argbValue As Integer
+			If Integer.TryParse(value, argbValue) Then
+				AppointmentColorPicker.SelectedColor = Color.FromArgb(argbValue)
+			End If
+		End Set
+	End Property
+	```
 	
 
 4. In **DefaultCS**.aspx or **DefaultVB**.aspx
@@ -109,144 +109,144 @@ The advanced form looks like this:
 	* add AppointmentTemplate to display the subject and description
 	* add .rsAptSubject css class
 
-	**JavaScript**
-	
-		<telerik:RadScheduler RenderMode="Lightweight" runat="server" ID="RadScheduler1" Width="750px" SelectedDate="2009-03-30"
-		   DayStartTime="08:00:00" DayEndTime="18:00:00" CustomAttributeNames="AppointmentColor" Localization-AdvancedDescription="Subject"
-		   TimeZoneOffset="03:00:00" OnDataBound="RadScheduler1_DataBound" OnAppointmentDataBound="RadScheduler1_AppointmentDataBound"
-		   OnClientFormCreated="schedulerFormCreated">
-		   <AdvancedForm Modal="true" />
-		   <AppointmentTemplate>
-		  <div class="rsAptSubject">
-		   <%# Eval("Subject") %>
-		  </div>
-		  <%# Eval("Description") %>
-		 </AppointmentTemplate>
-		   <AdvancedEditTemplate>
-			   <scheduler:AdvancedForm runat="server" ID="AdvancedEditForm1" Mode="Edit" Subject='<%# Bind("Subject") %>'
-				   Start='<%# Bind("Start") %>' End='<%# Bind("End") %>' AppointmentColor='<%# Bind("AppointmentColor") %>'
-				   RecurrenceRuleText='<%# Bind("RecurrenceRule") %>' UserID='<%# Bind("User") %>'
-				   RoomID='<%# Bind("Room") %>' />
-		   </AdvancedEditTemplate>
-		   <AdvancedInsertTemplate>
-			   <scheduler:AdvancedForm runat="server" ID="AdvancedInsertForm1" Mode="Insert" Subject='<%# Bind("Subject") %>'
-				   Start='<%# Bind("Start") %>' End='<%# Bind("End") %>' AppointmentColor='<%# Bind("AppointmentColor") %>'
-				   RecurrenceRuleText='<%# Bind("RecurrenceRule") %>' UserID='<%# Bind("User") %>'
-				   RoomID='<%# Bind("Room") %>' />
-		   </AdvancedInsertTemplate>
-		</telerik:RadScheduler>      
+	```JavaScript
+	<telerik:RadScheduler RenderMode="Lightweight" runat="server" ID="RadScheduler1" Width="750px" SelectedDate="2009-03-30"
+	   DayStartTime="08:00:00" DayEndTime="18:00:00" CustomAttributeNames="AppointmentColor" Localization-AdvancedDescription="Subject"
+	   TimeZoneOffset="03:00:00" OnDataBound="RadScheduler1_DataBound" OnAppointmentDataBound="RadScheduler1_AppointmentDataBound"
+	   OnClientFormCreated="schedulerFormCreated">
+	   <AdvancedForm Modal="true" />
+	   <AppointmentTemplate>
+	  <div class="rsAptSubject">
+	   <%# Eval("Subject") %>
+	  </div>
+	  <%# Eval("Description") %>
+	 </AppointmentTemplate>
+	   <AdvancedEditTemplate>
+		   <scheduler:AdvancedForm runat="server" ID="AdvancedEditForm1" Mode="Edit" Subject='<%# Bind("Subject") %>'
+			   Start='<%# Bind("Start") %>' End='<%# Bind("End") %>' AppointmentColor='<%# Bind("AppointmentColor") %>'
+			   RecurrenceRuleText='<%# Bind("RecurrenceRule") %>' UserID='<%# Bind("User") %>'
+			   RoomID='<%# Bind("Room") %>' />
+	   </AdvancedEditTemplate>
+	   <AdvancedInsertTemplate>
+		   <scheduler:AdvancedForm runat="server" ID="AdvancedInsertForm1" Mode="Insert" Subject='<%# Bind("Subject") %>'
+			   Start='<%# Bind("Start") %>' End='<%# Bind("End") %>' AppointmentColor='<%# Bind("AppointmentColor") %>'
+			   RecurrenceRuleText='<%# Bind("RecurrenceRule") %>' UserID='<%# Bind("User") %>'
+			   RoomID='<%# Bind("Room") %>' />
+	   </AdvancedInsertTemplate>
+	</telerik:RadScheduler>      
+	```
 	
 
-	**CSS**
-	     
-		<style type="text/css">
-		   .RadScheduler .rsAptSubject
-		   {
-			   text-align: left;
-			   padding: 4px 0 1px;
-			   margin: 0 0 3px;
-			   font-size: 12px;
-			   font-weight: bold;
-			   color: #369;
-			   height: 17px;
-			   border-bottom: 1px solid #99DEFD;
-			   width: 100%;
-		   }  
-		.RadScheduler .rsAdvancedEdit .RadColorPicker label
-		{
+	```CSS
+	<style type="text/css">
+	   .RadScheduler .rsAptSubject
+	   {
+		   text-align: left;
+		   padding: 4px 0 1px;
+		   margin: 0 0 3px;
+		   font-size: 12px;
+		   font-weight: bold;
+		   color: #369;
+		   height: 17px;
+		   border-bottom: 1px solid #99DEFD;
+		   width: 100%;
+	   }  
+	.RadScheduler .rsAdvancedEdit .RadColorPicker label
+	{
 			 text-align: left;
 			 display: block;
 			 padding: 0;
-		}   
-		  
-		</style>  
+	}   
+	  
+	</style>  
+	```
 				
 
 5. In code behind of **Default**.aspx, handle **AppointmentDataBound** like this to set the color of the appointments:
 
-	**C#**
-	
-		protected void RadScheduler1_AppointmentDataBound(object sender, SchedulerEventArgs e)
+	```C#
+	protected void RadScheduler1_AppointmentDataBound(object sender, SchedulerEventArgs e)
+	{
+		int AppointmentArgbColorValue;
+		if (int.TryParse(e.Appointment.Attributes["AppointmentColor"], out AppointmentArgbColorValue))
 		{
-			int AppointmentArgbColorValue;
-			if (int.TryParse(e.Appointment.Attributes["AppointmentColor"], out AppointmentArgbColorValue))
-			{
-				e.Appointment.BackColor = Color.FromArgb(AppointmentArgbColorValue);
-				e.Appointment.BorderColor = Color.Black;
-				e.Appointment.BorderStyle = BorderStyle.Solid;
-				e.Appointment.BorderWidth = Unit.Pixel(1);
-			}
-			e.Appointment.ToolTip = e.Appointment.Subject + ": " + e.Appointment.Description;
+			e.Appointment.BackColor = Color.FromArgb(AppointmentArgbColorValue);
+			e.Appointment.BorderColor = Color.Black;
+			e.Appointment.BorderStyle = BorderStyle.Solid;
+			e.Appointment.BorderWidth = Unit.Pixel(1);
 		}
+		e.Appointment.ToolTip = e.Appointment.Subject + ": " + e.Appointment.Description;
+	}
+	```
 			
 		
-		**VB**
-			
-				Protected Sub RadScheduler1_AppointmentDataBound(ByVal sender As Object, ByVal e As SchedulerEventArgs)
-					Dim AppointmentArgbColorValue As Integer
-					If Integer.TryParse(e.Appointment.Attributes("AppointmentColor"), AppointmentArgbColorValue) Then
-						e.Appointment.BackColor = Color.FromArgb(AppointmentArgbColorValue)
-						e.Appointment.BorderColor = Color.Black
-						e.Appointment.BorderStyle = BorderStyle.Solid
-						e.Appointment.BorderWidth = Unit.Pixel(1)
-					End If
-					e.Appointment.ToolTip = e.Appointment.Subject + ": " + e.Appointment.Description
-				End Sub
+		```VB
+		Protected Sub RadScheduler1_AppointmentDataBound(ByVal sender As Object, ByVal e As SchedulerEventArgs)
+			Dim AppointmentArgbColorValue As Integer
+			If Integer.TryParse(e.Appointment.Attributes["AppointmentColor"], AppointmentArgbColorValue) Then
+				e.Appointment.BackColor = Color.FromArgb(AppointmentArgbColorValue)
+				e.Appointment.BorderColor = Color.Black
+				e.Appointment.BorderStyle = BorderStyle.Solid
+				e.Appointment.BorderWidth = Unit.Pixel(1)
+			End If
+			e.Appointment.ToolTip = e.Appointment.Subject + ": " + e.Appointment.Description
+		End Sub
+		```
 	
 
 6. Register **AdvancedForm**.**js** with the script manager for the page and handle RadScheduler's **OnClientFormCreated** event.
 
 	>note This is actually already done in the sample demo. This step is to serve just as a reminder.
 	
-	**ASP.NET**
-	     
-		<asp:ScriptManager ID="ScriptManager1" runat="server">
-		   <Scripts>
-			   <asp:ScriptReference Path="~/Modified_AddedDescription/CS/AdvancedForm.js" />
-		   </Scripts>
-		</asp:ScriptManager>
-		
-		<script type="text/javascript">
-		   //<![CDATA[
-			 // Dictionary containing the advanced template client object
-			 // for a given RadScheduler instance (the control ID is used as key).
-			 var schedulerTemplates = {};
-		 
-			 function schedulerFormCreated(scheduler, eventArgs) {
-				 // Create a client-side object only for the advanced templates
-				 var mode = eventArgs.get_mode();
-				 if (mode == Telerik.Web.UI.SchedulerFormMode.AdvancedInsert ||
-			mode == Telerik.Web.UI.SchedulerFormMode.AdvancedEdit) {
-					 // Initialize the client-side object for the advanced form
-					 var formElement = eventArgs.get_formElement();
-					 var templateKey = scheduler.get_id() + "_" + mode;             
-					 var advancedTemplate = schedulerTemplates[templateKey];                      
-					 if (!advancedTemplate)
-					 {
-						 // Initialize the template for this RadScheduler instance
-						 // and cache it in the schedulerTemplates dictionary
-							var schedulerElement = scheduler.get_element();
-							var isModal = scheduler.get_advancedFormSettings().modal;
-							advancedTemplate = new window.SchedulerAdvancedTemplate(schedulerElement, formElement, isModal);
-							advancedTemplate.initialize();
-							
-							schedulerTemplates[templateKey] = advancedTemplate;
-					 }
-					 // Are we using Web Service data binding?
-					 if (!scheduler.get_webServiceSettings().get_isEmpty()) {
-						 // Populate the form with the appointment data
-						 var apt = eventArgs.get_appointment();
-						 var isInsert = mode == Telerik.Web.UI.SchedulerFormMode.AdvancedInsert;
-						 var editSeries = eventArgs.get_editingRecurringSeries();
-						 advancedTemplate.populate(apt, isInsert, editSeries);
-					 }
+	```ASP.NET
+	<asp:ScriptManager ID="ScriptManager1" runat="server">
+	   <Scripts>
+		   <asp:ScriptReference Path="~/Modified_AddedDescription/CS/AdvancedForm.js" />
+	   </Scripts>
+	</asp:ScriptManager>
+	
+	<script type="text/javascript">
+	   //<![CDATA[
+		 // Dictionary containing the advanced template client object
+		 // for a given RadScheduler instance (the control ID is used as key).
+		 var schedulerTemplates = {};
+	 
+		 function schedulerFormCreated(scheduler, eventArgs) {
+			 // Create a client-side object only for the advanced templates
+			 var mode = eventArgs.get_mode();
+			 if (mode == Telerik.Web.UI.SchedulerFormMode.AdvancedInsert ||
+		mode == Telerik.Web.UI.SchedulerFormMode.AdvancedEdit) {
+				 // Initialize the client-side object for the advanced form
+				 var formElement = eventArgs.get_formElement();
+				 var templateKey = scheduler.get_id() + "_" + mode;             
+				 var advancedTemplate = schedulerTemplates[templateKey];                      
+				 if (!advancedTemplate)
+				 {
+					 // Initialize the template for this RadScheduler instance
+					 // and cache it in the schedulerTemplates dictionary
+						var schedulerElement = scheduler.get_element();
+						var isModal = scheduler.get_advancedFormSettings().modal;
+						advancedTemplate = new window.SchedulerAdvancedTemplate(schedulerElement, formElement, isModal);
+						advancedTemplate.initialize();
+						
+						schedulerTemplates[templateKey] = advancedTemplate;
+				 }
+				 // Are we using Web Service data binding?
+				 if (!scheduler.get_webServiceSettings().get_isEmpty()) {
+					 // Populate the form with the appointment data
+					 var apt = eventArgs.get_appointment();
+					 var isInsert = mode == Telerik.Web.UI.SchedulerFormMode.AdvancedInsert;
+					 var editSeries = eventArgs.get_editingRecurringSeries();
+					 advancedTemplate.populate(apt, isInsert, editSeries);
 				 }
 			 }
-		
-		   //]]>
-		</script>
-		<telerik:RadScheduler RenderMode="Lightweight" runat="server" ID="RadScheduler1"
-		 OnClientFormCreated="schedulerFormCreated" .../>
+		 }
+	
+	   //]]>
+	</script>
+	<telerik:RadScheduler RenderMode="Lightweight" runat="server" ID="RadScheduler1"
+	 OnClientFormCreated="schedulerFormCreated" .../>
+	```
 					
 7. Run and test the application. If you experience problems, please refer to the **Modified_AddedDescription** folder for a solution.
 
@@ -282,19 +282,18 @@ In this tutorial, we will show how to add to the advanced form a RadColorPicker 
 
 3. In **AdvancedForm**.**ascx** add the following code right above the Custom Attributes panel:
 
-	**ASP.NET**
-	
-		<label>Color: </label>
-		<telerik:RadColorPicker RenderMode="Lightweight" ID="AppointmentColorPicker" CssClass="rsAdvResourceValue" NoColorText="transparent" ShowIcon="true" PaletteModes="HSV"
-		   runat="server">
-		</telerik:RadColorPicker>     
+	```ASP.NET
+	<label>Color: </label>
+	<telerik:RadColorPicker RenderMode="Lightweight" ID="AppointmentColorPicker" CssClass="rsAdvResourceValue" NoColorText="transparent" ShowIcon="true" PaletteModes="HSV"
+	   runat="server">
+	</telerik:RadColorPicker>     
+	```
 	
 
 
 4. In code-behind of the **AdvancedForm** user control add the following code:
 
-	**C#**
-	
+	```C#
 	    // Attributes and resources
 	    [Bindable(BindableSupport.Yes, BindingDirection.TwoWay)]
 	    public string AppointmentColor
@@ -310,10 +309,10 @@ In this tutorial, we will show how to add to the advanced form a RadColorPicker 
 	                AppointmentColorPicker.SelectedColor = Color.FromArgb(argbValue);
 	        }
 	    } 
+	```
 	
 
-	**VB**
-	
+	```VB
 	    ' Attributes and resources
 
 	    <Bindable(BindableSupport.Yes, BindingDirection.TwoWay)> _
@@ -328,85 +327,86 @@ In this tutorial, we will show how to add to the advanced form a RadColorPicker 
 	            End If
 	        End Set
 	    End Property
+	```
 	
 
 
 5. In **AdvancedForm.js** add a method to get the client object of RadColorPicker:
 
-	**JavaScript**
-		
-		_getAppointmentColorPicker: function() {
-			   return $find(this._templateId + "_AppointmentColorPicker");
-		   }      
+	```JavaScript
+	_getAppointmentColorPicker: function() {
+		   return $find(this._templateId + "_AppointmentColorPicker");
+	   }      
+	```
 			
 
 6. Add a method to save the RadColorPicker's selected color to the AppointmentColor custom attribute.
 
-	**JavaScript**
-	
-		_saveAppointmentColor: function(apt) {
-		   var template = this;
-		   var aptAttributes = apt.get_attributes();
-		   var appointmentColorPicker = this._getAppointmentColorPicker();       
-		   if (!appointmentColorPicker)
-			   return;
-		   aptAttributes.removeAttribute("AppointmentColor");
-		   aptAttributes.setAttribute("AppointmentColor",   appointmentColorPicker.get_selectedColor());
-		}       
+	```JavaScript
+	_saveAppointmentColor: function(apt) {
+	   var template = this;
+	   var aptAttributes = apt.get_attributes();
+	   var appointmentColorPicker = this._getAppointmentColorPicker();       
+	   if (!appointmentColorPicker)
+		   return;
+	   aptAttributes.removeAttribute("AppointmentColor");
+	   aptAttributes.setAttribute("AppointmentColor",   appointmentColorPicker.get_selectedColor());
+	}       
+	```
 		
 7. In the populate method, set the RadColorPicker'sselected color to the value of the AppointmentColor custom attribute:
 
-	**JavaScript**
-	     
-		populate: function(apt, isInsert, editSeries) {
-		 * * *
-		  this._getAppointmentColorPicker().set_selectedColor(apt.get_attributes().getAttribute("AppointmentColor"));
-			   
-		 * * *
-		}
+	```JavaScript
+	populate: function(apt, isInsert, editSeries) {
+	 * * *
+	  this._getAppointmentColorPicker().set_selectedColor(apt.get_attributes().getAttribute("AppointmentColor"));
+		   
+	 * * *
+	}
+	```
 				
 8. In the saveClicked method, call saveAppointmentColor():
 
-	**JavaScript**
-	
-		_saveClicked : function ()
-		{
-		 * * *    
-		   this._saveAppointmentColor(apt);
-		 * * *
-		}       
+	```JavaScript
+	_saveClicked : function ()
+	{
+	 * * *    
+	   this._saveAppointmentColor(apt);
+	 * * *
+	}       
+	```
 			
 9. In **Default.aspx** handle **OnClientAppointmentDataBound** like this to apply the selected color to the appointment:
 
-	**JavaScript**
-	
-		function OnClientAppointmentDataBound(sender, eventArgs) {
-		   var app = eventArgs.get_appointment();
-		   //debugger;
-		   var backColor = app.get_attributes().getAttribute("AppointmentColor");
+	```JavaScript
+	function OnClientAppointmentDataBound(sender, eventArgs) {
+	   var app = eventArgs.get_appointment();
+	   //debugger;
+	   var backColor = app.get_attributes().getAttribute("AppointmentColor");
+	   
+	   if (backColor)
+		   app.set_backColor(backColor);
 		   
-		   if (backColor)
-			   app.set_backColor(backColor);
-			   
-		   app.set_borderColor("black");
-		   app.set_borderWidth("1");
-		 }
-		//]]>
-		</script>
-		<telerik:RadScheduler RenderMode="Lightweight" runat="server" ID="RadScheduler1"      
-			OnClientAppointmentDataBound="OnClientAppointmentDataBound">
-		</telerik:RadScheduler>     
+	   app.set_borderColor("black");
+	   app.set_borderWidth("1");
+	 }
+	//]]>
+	</script>
+	<telerik:RadScheduler RenderMode="Lightweight" runat="server" ID="RadScheduler1"      
+		OnClientAppointmentDataBound="OnClientAppointmentDataBound">
+	</telerik:RadScheduler>     
+	```
 	
 10. In **Default.aspx** add the following css fix for RadColorPicker:
 
-	**ASP.NET**
-	 
-		 .RadScheduler .rsAdvancedEdit .RadColorPicker label
-		{
-		   text-align: left;
-		   display: block;
-		   padding: 0;
-		}
+	```ASP.NET
+	 .RadScheduler .rsAdvancedEdit .RadColorPicker label
+	{
+	   text-align: left;
+	   display: block;
+	   padding: 0;
+	}
+	```
 				
 11. Run and test the application. If you experience problem, please refer to the sample in the **Modified_AddColorPicker** folder.
 

--- a/controls/scheduler/export/export-to-icalendar.md
+++ b/controls/scheduler/export/export-to-icalendar.md
@@ -20,51 +20,51 @@ position: 1
 
 1. Add a [custom template]({%slug scheduler/appearance-and-styling/templates%}) to the scheduler so that each appointment has an export button:
 
-	**ASP.NET**
-	 
-		 <AppointmentTemplate>
-		 <%# Eval("Subject") %>
-		 <div style="text-align: right;">
-			<span style="cursor: pointer; cursor: hand;">
-			  <asp:ImageButton runat="server" ID="Button1" ImageUrl="Outlook.gif" AlternateText="Export to iCalendar"
-			  CommandName="Export" OnClientClick="Export(this, event); return false;" />
-			</span>
-		 </div>
-		</AppointmentTemplate>
+	```ASP.NET
+	 <AppointmentTemplate>
+	 <%# Eval("Subject") %>
+	 <div style="text-align: right;">
+		<span style="cursor: pointer; cursor: hand;">
+		  <asp:ImageButton runat="server" ID="Button1" ImageUrl="Outlook.gif" AlternateText="Export to iCalendar"
+		  CommandName="Export" OnClientClick="Export(this, event); return false;" />
+		</span>
+	 </div>
+	</AppointmentTemplate>
+	```
 	
 
 
 1. On the codebehind page for your Web page, add a private helper method to your Page class that can write the ICalendar strings youto the HTTP response:
 
-	**C#**
+	```C#
+	private void WriteCalendar(string data)
+	{
+		HttpResponse response = Page.Response;
+		response.Clear();
+		response.Buffer = true;
+		response.ContentType = "text/calendar";
+		response.ContentEncoding = Encoding.UTF8;
+		response.Charset = "utf-8";
+		response.AddHeader("Content-Disposition", "attachment;filename=\"RadSchedulerExport.ics\"");
+		response.Write(data);
+		response.End();
+	} 
+	```
 	
-		private void WriteCalendar(string data)
-		{
-			HttpResponse response = Page.Response;
-			response.Clear();
-			response.Buffer = true;
-			response.ContentType = "text/calendar";
-			response.ContentEncoding = Encoding.UTF8;
-			response.Charset = "utf-8";
-			response.AddHeader("Content-Disposition", "attachment;filename=\"RadSchedulerExport.ics\"");
-			response.Write(data);
-			response.End();
-		} 
-	
-	**VB**
-	
-		Private Sub WriteCalendar(ByVal data As String)
-			Dim response As HttpResponse = Page.Response
-			response.Clear()
-			response.Buffer = True
-			response.ContentType = "text/calendar"
-			response.ContentEncoding = Encoding.UTF8
-			response.Charset = "utf-8"
-			response.AddHeader("Content-Disposition", _
-					  "attachment;filename=""RadSchedulerExport.ics""")
-			response.Write(data)
-			response.[End]()
-		End Sub
+	```VB
+	Private Sub WriteCalendar(ByVal data As String)
+		Dim response As HttpResponse = Page.Response
+		response.Clear()
+		response.Buffer = True
+		response.ContentType = "text/calendar"
+		response.ContentEncoding = Encoding.UTF8
+		response.Charset = "utf-8"
+		response.AddHeader("Content-Disposition", _
+				  "attachment;filename=""RadSchedulerExport.ics""")
+		response.Write(data)
+		response.[End]()
+	End Sub
+	```
 			
 
 
@@ -72,49 +72,49 @@ position: 1
 
 
 
-	**C#**
-	
-		protected void RadScheduler1_AppointmentCommand(object sender, AppointmentCommandEventArgs e)
+	```C#
+	protected void RadScheduler1_AppointmentCommand(object sender, AppointmentCommandEventArgs e)
+	{
+		if (e.CommandName == "Export")
 		{
-			if (e.CommandName == "Export")
-			{
-				//exporting a single appointment that supports time zones
-				WriteCalendar(RadScheduler.ExportToICalendar(e.Container.Appointment, true));
-			}
-		}  
+			//exporting a single appointment that supports time zones
+			WriteCalendar(RadScheduler.ExportToICalendar(e.Container.Appointment, true));
+		}
+	}  
+	```
 	
 
-	**VB**
-	
-		Protected Sub RadScheduler1_AppointmentCommand(ByVal sender As Object,
-		ByVal e As AppointmentCommandEventArgs) Handles RadScheduler1.AppointmentCommand
-			If e.CommandName = "Export" Then
-				'exporting a single appointment that supports time zones
-				WriteCalendar(RadScheduler.ExportToICalendar(e.Container.Appointment, True))
-			End If
-		End Sub
+	```VB
+	Protected Sub RadScheduler1_AppointmentCommand(ByVal sender As Object,
+	ByVal e As AppointmentCommandEventArgs) Handles RadScheduler1.AppointmentCommand
+		If e.CommandName = "Export" Then
+			'exporting a single appointment that supports time zones
+			WriteCalendar(RadScheduler.ExportToICalendar(e.Container.Appointment, True))
+		End If
+	End Sub
+	```
 	
 
 1. Add **ImageButton** control with the same image as the one in the appointment template. On its **Click** event,add an event handler to export all of the appointments in the scheduler. This event handler calls the RadScheduler's static **ExportToICalendar** method to convert a collection of appointments to the ICalendar format:
 
 
 
-	**C#**
-	
-		protected void Button1_Click(object sender, ImageClickEventArgs e)
-		{
-			//exporting a collection of appointments that do not support time zones
-			WriteCalendar(RadScheduler.ExportToICalendar(RadScheduler1.Appointments, false));
-		}
+	```C#
+	protected void Button1_Click(object sender, ImageClickEventArgs e)
+	{
+		//exporting a collection of appointments that do not support time zones
+		WriteCalendar(RadScheduler.ExportToICalendar(RadScheduler1.Appointments, false));
+	}
+	```
 	
 
-	**VB**
-	
-	    Protected Sub Button1_Click(ByVal sender As Object,
-	     ByVal e As ImageClickEventArgs) Handles Button1.Click
-	        'exporting a collection of appointments that do not support time zones
-	        WriteCalendar(RadScheduler.ExportToICalendar(RadScheduler1.Appointments, False))
-	    End Sub
+	```VB
+	Protected Sub Button1_Click(ByVal sender As Object,
+	 ByVal e As ImageClickEventArgs) Handles Button1.Click
+	     'exporting a collection of appointments that do not support time zones
+	     WriteCalendar(RadScheduler.ExportToICalendar(RadScheduler1.Appointments, False))
+	 End Sub
+	```
 	
 
 >note The `ExportToICalendar` method sets the *Location* of the .ics event to the value of the *Location* attribute of the exported appointment.

--- a/controls/scheduler/how-to/change-the-end-date-when-the-start-date-changes.md
+++ b/controls/scheduler/how-to/change-the-end-date-when-the-start-date-changes.md
@@ -18,40 +18,40 @@ Here are the steps:
 
 1. Subscribe to the [OnFormCreated]({%slug scheduler/server-side-programming/server-events/formcreated%}) event and find the **RadDatePicker** object.Then subscribe to its **OnDateSelected** event:
 
-	**C#**
-	     
-		protected void RadScheduler1_FormCreated(object sender, SchedulerFormCreatedEventArgs e)
-		{    
-			RadDatePicker startDate = e.Container.FindControl("StartDate") as RadDatePicker;    
-			if (startDate != null)    
-			{        
-				// advanced form is shown        
-				startDate.ClientEvents.OnDateSelected = "changeEndDate";    
-			}
+	```C#
+	protected void RadScheduler1_FormCreated(object sender, SchedulerFormCreatedEventArgs e)
+	{    
+		RadDatePicker startDate = e.Container.FindControl("StartDate") as RadDatePicker;    
+		if (startDate != null)    
+		{        
+			// advanced form is shown        
+			startDate.ClientEvents.OnDateSelected = "changeEndDate";    
 		}
+	}
+	```
 				
 
-	**VB**
-	
-		Protected Sub RadScheduler1_FormCreated(ByVal sender As Object, ByVal e As SchedulerFormCreatedEventArgs)
-			Dim startDate As RadDatePicker = TryCast(e.Container.FindControl("StartDate"), RadDatePicker)
-			If startDate IsNot Nothing Then
-				' advanced form is shown  
-				startDate.ClientEvents.OnDateSelected = "changeEndDate"
-			End If
-		End Sub
+	```VB
+	Protected Sub RadScheduler1_FormCreated(ByVal sender As Object, ByVal e As SchedulerFormCreatedEventArgs)
+		Dim startDate As RadDatePicker = TryCast(e.Container.FindControl("StartDate"), RadDatePicker)
+		If startDate IsNot Nothing Then
+			' advanced form is shown  
+			startDate.ClientEvents.OnDateSelected = "changeEndDate"
+		End If
+	End Sub
+	```
 	
 2. Define the changeEndDate javascript method as follows:
 
-	**JavaScript**
-	     
-		<telerik:RadScriptBlock ID="RadScriptBlock1" runat="server">
-		function changeEndDate(sender, e)
-		{    
-			var endDatePickerID = sender.get_id().replace("StartDate", "EndDate");    
-			var endDatePicker = $find(endDatePickerID);    
-			endDatePicker.set_selectedDate(sender.get_selectedDate());
-		}
-		</telerik:RadScriptBlock>
+	```JavaScript
+	<telerik:RadScriptBlock ID="RadScriptBlock1" runat="server">
+	function changeEndDate(sender, e)
+	{    
+		var endDatePickerID = sender.get_id().replace("StartDate", "EndDate");    
+		var endDatePicker = $find(endDatePickerID);    
+		endDatePicker.set_selectedDate(sender.get_selectedDate());
+	}
+	</telerik:RadScriptBlock>
+	```
 				
 

--- a/controls/scheduler/how-to/customize-the-advanced-form-template.md
+++ b/controls/scheduler/how-to/customize-the-advanced-form-template.md
@@ -53,12 +53,12 @@ The advanced form looks like this:
 
 2. In **AdvancedForm**.**ascx** add the following code right above the Custom Attributes panel:
 
-	**ASP.NET**
-	
-		<label>Color: </label>
-		<telerik:RadColorPicker RenderMode="Lightweight" ID="AppointmentColorPicker" CssClass="rsAdvResourceValue" NoColorText="transparent" ShowIcon="true" PaletteModes="HSV"
-		   runat="server">
-		</telerik:RadColorPicker>     	
+    ```ASP.NET
+    <label>Color: </label>
+    <telerik:RadColorPicker RenderMode="Lightweight" ID="AppointmentColorPicker" CssClass="rsAdvResourceValue" NoColorText="transparent" ShowIcon="true" PaletteModes="HSV"
+       runat="server">
+    </telerik:RadColorPicker>     	
+    ```
 	
 
 3. Expose an **AppointmentColor** property using the RadColorpicker control added in step 2 above.
@@ -296,12 +296,12 @@ In this tutorial, we will show how to add to the advanced form a RadColorPicker 
 
 3. In **AdvancedForm**.**ascx** add the following code right above the Custom Attributes panel:
 
-	**ASP.NET**
-
-		<label>Color: </label>
-		<telerik:RadColorPicker RenderMode="Lightweight" ID="AppointmentColorPicker" CssClass="rsAdvResourceValue" NoColorText="transparent" ShowIcon="true" PaletteModes="HSV"
-		   runat="server">
-		</telerik:RadColorPicker>     
+    ```ASP.NET
+    <label>Color: </label>
+    <telerik:RadColorPicker RenderMode="Lightweight" ID="AppointmentColorPicker" CssClass="rsAdvResourceValue" NoColorText="transparent" ShowIcon="true" PaletteModes="HSV"
+       runat="server">
+    </telerik:RadColorPicker>     
+    ```
 	
 4. In code-behind of the **AdvancedForm** user control add the following code:
 

--- a/controls/scheduler/how-to/replace-the-edit-form.md
+++ b/controls/scheduler/how-to/replace-the-edit-form.md
@@ -33,80 +33,80 @@ You can use the **OnClientAppointmentEditing** and **OnClientAppointmentInsertin
 1. Give the AJAX manager an **AjaxRequest** event handler to rebind the scheduler after an edit:
 
 
-	**C#**
-	
-		protected void RadAjaxManager1_AjaxRequest(object sender, AjaxRequestEventArgs e)
+	```C#
+	protected void RadAjaxManager1_AjaxRequest(object sender, AjaxRequestEventArgs e)
+	{
+		if (e.Argument == "RebindScheduler")
 		{
-			if (e.Argument == "RebindScheduler")
-			{
-				RadScheduler1.Rebind();
-			}
+			RadScheduler1.Rebind();
 		}
+	}
+	```
 	    
 
-	**VB**
-	
-		Protected Sub RadAjaxManager1_AjaxRequest( _
-						ByVal sender As Object, _
-						ByVal e As AjaxRequestEventArgs)
-			If e.Argument = "RebindScheduler" Then
-				RadScheduler1.Rebind()
-			End If
-		End Sub
+	```VB
+	Protected Sub RadAjaxManager1_AjaxRequest( _
+				ByVal sender As Object, _
+				ByVal e As AjaxRequestEventArgs)
+		If e.Argument = "RebindScheduler" Then
+			RadScheduler1.Rebind()
+		End If
+	End Sub
+	```
 	
 
 
 1. Switch to Source view and add the following javascript functions to your page:
 
-	**JavaScript**
-	
-		function AppointmentEditing(sender, eventArgs)
+	```JavaScript
+	function AppointmentEditing(sender, eventArgs)
+	{
+		 var apt = eventArgs.get_appointment();
+		 window.radopen("AdvancedForm.aspx?Mode=Edit&AppointmentId=" + apt.get_id(), "AdvancedForm");
+		 eventArgs.set_cancel(true);
+	}
+
+	function AppointmentInserting(sender, eventArgs)
+	{
+		 var start = formatDate(eventArgs.get_startTime());
+		 var isAllDay = eventArgs.get_isAllDay();
+		 // New appointment
+		 window.radopen("AdvancedForm.aspx?Mode=Insert&Start=" + start + "&IsAllDay=" + isAllDay, "AdvancedForm");   
+		 eventArgs.set_cancel(true);
+	}
+
+	function formatDate(date)
+	{
+		var year = padNumber(date.getUTCFullYear(), 4);
+		var month = padNumber(date.getUTCMonth() + 1, 2);
+		var day = padNumber(date.getUTCDate(), 2);
+		var hour = padNumber(date.getUTCHours(), 2);
+		var minute = padNumber(date.getUTCMinutes(), 2);
+
+		return year + month + day + hour + minute;
+	}
+
+	function padNumber(number, totalDigits)
+	{
+		number = number.toString();
+		var padding = '';
+		if (totalDigits > number.length)
 		{
-			 var apt = eventArgs.get_appointment();
-			 window.radopen("AdvancedForm.aspx?Mode=Edit&AppointmentId=" + apt.get_id(), "AdvancedForm");
-			 eventArgs.set_cancel(true);
+		 for (i = 0; i < (totalDigits - number.length); i++)
+		 {
+		   padding += '0';
+		 }
 		}
 
-		function AppointmentInserting(sender, eventArgs)
-		{
-			 var start = formatDate(eventArgs.get_startTime());
-			 var isAllDay = eventArgs.get_isAllDay();
-			 // New appointment
-			 window.radopen("AdvancedForm.aspx?Mode=Insert&Start=" + start + "&IsAllDay=" + isAllDay, "AdvancedForm");   
-			 eventArgs.set_cancel(true);
-		}
+		return padding + number.toString();
+	}
 
-		function formatDate(date)
-		{
-			var year = padNumber(date.getUTCFullYear(), 4);
-			var month = padNumber(date.getUTCMonth() + 1, 2);
-			var day = padNumber(date.getUTCDate(), 2);
-			var hour = padNumber(date.getUTCHours(), 2);
-			var minute = padNumber(date.getUTCMinutes(), 2);
-
-			return year + month + day + hour + minute;
-		}
-
-		function padNumber(number, totalDigits)
-		{
-			number = number.toString();
-			var padding = '';
-			if (totalDigits > number.length)
-			{
-			 for (i = 0; i < (totalDigits - number.length); i++)
-			 {
-			   padding += '0';
-			 }
-			}
-
-			return padding + number.toString();
-		}
-
-		function refreshScheduler()
-		{
-			 var ajaxManager = $find("RadAjaxManager1");
-			 ajaxManager.ajaxRequest('RebindScheduler');
-		}
+	function refreshScheduler()
+	{
+		 var ajaxManager = $find("RadAjaxManager1");
+		 ajaxManager.ajaxRequest('RebindScheduler');
+	}
+	```
 			
 
 

--- a/controls/scheduler/how-to/set-different-styles-to-appointments-.md
+++ b/controls/scheduler/how-to/set-different-styles-to-appointments-.md
@@ -225,38 +225,38 @@ If you need to use your own custom style for the appointments, here is how to pr
 
 2. Include the following css rule in the head of your page:
 
-	**CSS**
-	
-		<style type="text/css">
-		   .RadScheduler .MyCustomAppointmentStyle .rsAptContent,
-		   .RadScheduler .MyCustomAppointmentStyle .rsAptMid .rsAptIn,
-		   .RadScheduler .MyCustomAppointmentStyle .rsAptMid,
-		   .RadScheduler .MyCustomAppointmentStyle .rsAptOut
-		   {
-			background-image: url('Scheduler/MyCustomBackgroundImage.png');
-		   }
-		   .RadScheduler .MyCustomAppointmentStyle .rsAptContent
-		   {
-			/*font style*/
-			color: Blue;
-		   }
-		</style>  
+	```CSS
+	<style type="text/css">
+	   .RadScheduler .MyCustomAppointmentStyle .rsAptContent,
+	   .RadScheduler .MyCustomAppointmentStyle .rsAptMid .rsAptIn,
+	   .RadScheduler .MyCustomAppointmentStyle .rsAptMid,
+	   .RadScheduler .MyCustomAppointmentStyle .rsAptOut
+	   {
+		background-image: url('Scheduler/MyCustomBackgroundImage.png');
+	   }
+	   .RadScheduler .MyCustomAppointmentStyle .rsAptContent
+	   {
+		/*font style*/
+		color: Blue;
+	   }
+	</style>  
+	```
 				
 3. Set the appointment **CssClass** property:
 
-	**C#**
-	
-		protected void RadScheduler1_AppointmentDataBound(object sender, Telerik.Web.UI.SchedulerEventArgs e)
-		{
-			e.Appointment.CssClass = "MyCustomAppointmentStyle";
-		}  
+	```C#
+	protected void RadScheduler1_AppointmentDataBound(object sender, Telerik.Web.UI.SchedulerEventArgs e)
+	{
+		e.Appointment.CssClass = "MyCustomAppointmentStyle";
+	}  
+	```
 	    
 
-	**VB**
-			
-		Protected Sub RadScheduler1_AppointmentDataBound(ByVal sender As Object, ByVal e As Telerik.Web.UI.SchedulerEventArgs) Handles RadScheduler1.AppointmentDataBound
-			e.Appointment.CssClass = "MyCustomAppointmentStyle"
-		End Sub
+	```VB
+	Protected Sub RadScheduler1_AppointmentDataBound(ByVal sender As Object, ByVal e As Telerik.Web.UI.SchedulerEventArgs) Handles RadScheduler1.AppointmentDataBound
+		e.Appointment.CssClass = "MyCustomAppointmentStyle"
+	End Sub
+	```
 	
 
 The background images for the appointment styles can be found in your local installation of the Telerik.Web.UI suit -> *Skins\Common\Scheduler* and the cssrules are defined in **Scheduler.css** in the Skins folder.

--- a/controls/scheduler/web-service-binding/overview.md
+++ b/controls/scheduler/web-service-binding/overview.md
@@ -31,15 +31,15 @@ Here is a step-by-step tutorial on how to bind RadScheduler to Web Services:
 
 2. From the toolbox drag RadScheduler and a script manager to the default page. The generated markup will look like this:
 
-	**ASP.NET**
-	
-		<form id="form2" runat="server">   
-		   <asp:ScriptManager ID="ScriptManager1" runat="server">
-		   </asp:ScriptManager>
-		   <telerik:RadScheduler RenderMode="Lightweight" ID="RadScheduler1" runat="server" Height=""
-			   HoursPanelTimeFormat="htt" ValidationGroup="RadScheduler1">
-		   </telerik:RadScheduler>
-		</form>      
+	```ASP.NET
+	<form id="form2" runat="server">   
+	   <asp:ScriptManager ID="ScriptManager1" runat="server">
+	   </asp:ScriptManager>
+	   <telerik:RadScheduler RenderMode="Lightweight" ID="RadScheduler1" runat="server" Height=""
+		   HoursPanelTimeFormat="htt" ValidationGroup="RadScheduler1">
+	   </telerik:RadScheduler>
+	</form>      
+	```
 	
 
 
@@ -53,69 +53,69 @@ Here is a step-by-step tutorial on how to bind RadScheduler to Web Services:
 	* A Controller property of type WebServiceAppointmentController. This class is used as a wrapper for the Data Provider.
 	* Public methods for creating, updating and deleting appointments, as shown below:
 
-	**C#**
-	     
-		using System.Collections.Generic;
-		using System.Web.Script.Services;
-		using System.Web.Services;
-		using Telerik.Web.UI;
-		[WebService]
-		[WebServiceBinding(ConformsTo = WsiProfiles.BasicProfile1_1)]
-		[ScriptService]
-		public class SchedulerWebService : WebService
-		{
-			private WebServiceAppointmentController _controller;
+	```C#
+	using System.Collections.Generic;
+	using System.Web.Script.Services;
+	using System.Web.Services;
+	using Telerik.Web.UI;
+	[WebService]
+	[WebServiceBinding(ConformsTo = WsiProfiles.BasicProfile1_1)]
+	[ScriptService]
+	public class SchedulerWebService : WebService
+	{
+		private WebServiceAppointmentController _controller;
 
-			/// <summary>
-			/// The WebServiceAppointmentController class is used as a facade to the SchedulerProvider.
-			/// </summary>
-			private WebServiceAppointmentController Controller
-			{
-			 get
-			 {
-			  if (_controller == null)
-			  {
-			   _controller = new WebServiceAppointmentController(new XmlSchedulerProvider(Server.MapPath("~/App_Data/Appointments_Outlook.xml"), true));
-			  }
-			  return _controller;
-			 }
-			}
-			[WebMethod]
-			public IEnumerable<AppointmentData> GetAppointments(SchedulerInfo schedulerInfo)
-			{
-			 return Controller.GetAppointments(schedulerInfo);
-			}
-			[WebMethod]
-			public IEnumerable<AppointmentData> InsertAppointment(SchedulerInfo schedulerInfo, AppointmentData appointmentData)
-			{
-			 return Controller.InsertAppointment(schedulerInfo, appointmentData);
-			}
-			[WebMethod]
-			public IEnumerable<AppointmentData> UpdateAppointment(SchedulerInfo schedulerInfo, AppointmentData appointmentData)
-			{
-			 return Controller.UpdateAppointment(schedulerInfo, appointmentData);
-			}
-			[WebMethod]
-			public IEnumerable<AppointmentData> CreateRecurrenceException(SchedulerInfo schedulerInfo, AppointmentData recurrenceExceptionData)
-			{
-			 return Controller.CreateRecurrenceException(schedulerInfo, recurrenceExceptionData);
-			}
-			[WebMethod]
-			public IEnumerable<AppointmentData> RemoveRecurrenceExceptions(SchedulerInfo schedulerInfo, AppointmentData masterAppointmentData)
-			{
-			 return Controller.RemoveRecurrenceExceptions(schedulerInfo, masterAppointmentData);
-			}
-			[WebMethod]
-			public IEnumerable<AppointmentData> DeleteAppointment(SchedulerInfo schedulerInfo, AppointmentData appointmentData, bool deleteSeries)
-			{
-			 return Controller.DeleteAppointment(schedulerInfo, appointmentData, deleteSeries);
-			}
-			[WebMethod]
-			public IEnumerable<ResourceData> GetResources(SchedulerInfo schedulerInfo)
-			{
-			 return Controller.GetResources(schedulerInfo);
-			}
-		} 
+		/// <summary>
+		/// The WebServiceAppointmentController class is used as a facade to the SchedulerProvider.
+		/// </summary>
+		private WebServiceAppointmentController Controller
+		{
+		 get
+		 {
+		  if (_controller == null)
+		  {
+		   _controller = new WebServiceAppointmentController(new XmlSchedulerProvider(Server.MapPath("~/App_Data/Appointments_Outlook.xml"), true));
+		  }
+		  return _controller;
+		 }
+		}
+		[WebMethod]
+		public IEnumerable<AppointmentData> GetAppointments(SchedulerInfo schedulerInfo)
+		{
+		 return Controller.GetAppointments(schedulerInfo);
+		}
+		[WebMethod]
+		public IEnumerable<AppointmentData> InsertAppointment(SchedulerInfo schedulerInfo, AppointmentData appointmentData)
+		{
+		 return Controller.InsertAppointment(schedulerInfo, appointmentData);
+		}
+		[WebMethod]
+		public IEnumerable<AppointmentData> UpdateAppointment(SchedulerInfo schedulerInfo, AppointmentData appointmentData)
+		{
+		 return Controller.UpdateAppointment(schedulerInfo, appointmentData);
+		}
+		[WebMethod]
+		public IEnumerable<AppointmentData> CreateRecurrenceException(SchedulerInfo schedulerInfo, AppointmentData recurrenceExceptionData)
+		{
+		 return Controller.CreateRecurrenceException(schedulerInfo, recurrenceExceptionData);
+		}
+		[WebMethod]
+		public IEnumerable<AppointmentData> RemoveRecurrenceExceptions(SchedulerInfo schedulerInfo, AppointmentData masterAppointmentData)
+		{
+		 return Controller.RemoveRecurrenceExceptions(schedulerInfo, masterAppointmentData);
+		}
+		[WebMethod]
+		public IEnumerable<AppointmentData> DeleteAppointment(SchedulerInfo schedulerInfo, AppointmentData appointmentData, bool deleteSeries)
+		{
+		 return Controller.DeleteAppointment(schedulerInfo, appointmentData, deleteSeries);
+		}
+		[WebMethod]
+		public IEnumerable<ResourceData> GetResources(SchedulerInfo schedulerInfo)
+		{
+		 return Controller.GetResources(schedulerInfo);
+		}
+	} 
+	```
 
 5. Copy the **Appointments_Outlook.xml** file to the App_Data folder of your web site. It’s located at:**
 
@@ -125,12 +125,12 @@ Here is a step-by-step tutorial on how to bind RadScheduler to Web Services:
 
 6. Set the **Path** and **ResourcePopulationMode** of RadScheduler's WebServiceSettings as shown below:
 
-	**ASP.NET**
-			
-		<telerik:RadScheduler RenderMode="Lightweight" runat="server" ID="RadScheduler1" SelectedView="WeekView" SelectedDate="2009-02-02"
-		  TimeZoneOffset="03:00:00" StartEditingInAdvancedForm="false">
-		  <WebServiceSettings Path="SchedulerWebService.asmx" ResourcePopulationMode="ServerSide" />
-		</telerik:RadScheduler> 
+	```ASP.NET
+	<telerik:RadScheduler RenderMode="Lightweight" runat="server" ID="RadScheduler1" SelectedView="WeekView" SelectedDate="2009-02-02"
+	  TimeZoneOffset="03:00:00" StartEditingInAdvancedForm="false">
+	  <WebServiceSettings Path="SchedulerWebService.asmx" ResourcePopulationMode="ServerSide" />
+	</telerik:RadScheduler> 
+	```
 			
 
 

--- a/controls/scheduler/web-service-binding/sending-additional-information-to-the-web-service.md
+++ b/controls/scheduler/web-service-binding/sending-additional-information-to-the-web-service.md
@@ -22,39 +22,39 @@ In our examples, the Web Service methods take SchedulerInfo as first parameter, 
 
 1. Create a custom ISchedulerInfo implementation by inheriting from SchedulerInfo:
 
-	**C#**
-	     
-		public class MySchedulerInfo : SchedulerInfo
-		{
-		   public string User { get; set; }
-		   public MySchedulerInfo(ISchedulerInfo baseInfo, string user)
-			   : base(baseInfo)
-		   {
-			   User = user;
-		   }
-			public MySchedulerInfo() {}
-		}  
+	```C#
+	public class MySchedulerInfo : SchedulerInfo
+	{
+	   public string User { get; set; }
+	   public MySchedulerInfo(ISchedulerInfo baseInfo, string user)
+		   : base(baseInfo)
+	   {
+		   User = user;
+	   }
+		public MySchedulerInfo() {}
+	}  
+	```
 		
-	**VB**
-	
-		Public Class MySchedulerInfo
-		 Inherits SchedulerInfo
-		 Public Property User() As String
-		  Get
-		   Return m_User
-		  End Get
-		  Set
-		   m_User = Value
-		  End Set
-		 End Property
-		 Private m_User As String
-		 Public Sub New(baseInfo As ISchedulerInfo, userParam As String)
-		  MyBase.New(baseInfo)
-		  User = userParam
-		 End Sub
-		 Public Sub New()
-			End Sub
-		End Class 
+	```VB
+	Public Class MySchedulerInfo
+	 Inherits SchedulerInfo
+	 Public Property User() As String
+	  Get
+	   Return m_User
+	  End Get
+	  Set
+	   m_User = Value
+	  End Set
+	 End Property
+	 Private m_User As String
+	 Public Sub New(baseInfo As ISchedulerInfo, userParam As String)
+	  MyBase.New(baseInfo)
+	  User = userParam
+	 End Sub
+	 Public Sub New()
+		End Sub
+	End Class 
+	```
 	
 
 2. Populate the MySchedulerInfo properties in one of the following client-side events:
@@ -68,32 +68,32 @@ In our examples, the Web Service methods take SchedulerInfo as first parameter, 
 	
 	For example:
 
-	**C#**
-		 
-		function appointmentsPopulating(sender, eventArgs)
-		{
-		   eventArgs.get_schedulerInfo().User = "UserA";
-		} 
+	```C#
+	function appointmentsPopulating(sender, eventArgs)
+	{
+	   eventArgs.get_schedulerInfo().User = "UserA";
+	} 
+	```
 				
 
 3. Change the corresponding Web Service method to take MySchedulerInfo as parameter:
 
 
-	**C#**
-					
-		public IEnumerable<AppointmentData> GetAppointments(MySchedulerInfo schedulerInfo)
-		{
-			// Access schedulerInfo.User
-			return Controller.GetAppointments(schedulerInfo);
-		}
+	```C#
+	public IEnumerable<AppointmentData> GetAppointments(MySchedulerInfo schedulerInfo)
+	{
+		// Access schedulerInfo.User
+		return Controller.GetAppointments(schedulerInfo);
+	}
+	```
 			
 
-	**VB**
-				
-		Public Function GetAppointments(schedulerInfo As MySchedulerInfo) As IEnumerable(Of AppointmentData)
-			' Access schedulerInfo.User
-			Return Controller.GetAppointments(schedulerInfo)
-		End Function
+	```VB
+	Public Function GetAppointments(schedulerInfo As MySchedulerInfo) As IEnumerable(Of AppointmentData)
+		' Access schedulerInfo.User
+		Return Controller.GetAppointments(schedulerInfo)
+	End Function
+	```
 				
 
 Note that the schedulerInfo will be forwarded to the underlying provider. In order to access it you mustimplement the provider methods that take ISchedulerInfo as parameter. These methods were introduced in the Q3 2010release. For more information see [Sending additionalinformation to the provider]({%slug scheduler/data-binding/providers/sending-additional-information-to-the-provider%}).

--- a/controls/scriptmanager/cdn-support/custom-cdn-provider.md
+++ b/controls/scriptmanager/cdn-support/custom-cdn-provider.md
@@ -38,7 +38,6 @@ If you want to use your own **CDN provider** to host the Telerik UI for ASP.NET 
 	* Enable **Dynamic** and **Static** Compression
 	* Configure **RadScriptManager** and **RadStyleSheetManager**:
 
-		**ASP.NET**
 	  	````ASP.NET
 			<telerik:RadStyleSheetManager ID="RadStyleSheetManager1" runat="server">
 					<CdnSettings BaseUrl="http://my.favorite.cdn" BaseSecureUrl="https://my.favorite.cdn" TelerikCdn="Enabled" />

--- a/controls/skinmanager/overview.md
+++ b/controls/skinmanager/overview.md
@@ -263,13 +263,13 @@ The steps that you need to take in order to load skins by specifying a path are:
 
 1. Add a **SkinReference** in the RadSkinManager and set the **Path** property to point to the name of the folder containing the skin folders.
 
-    **ASP.NET**
-
-        <telerik:RadSkinManager runat="server" ID="RadSkinManager1">
-            <Skins>
-                <telerik:SkinReference Path="~/MySkins" />
-            </Skins>
-        </telerik:RadSkinManager>
+    ```ASP.NET
+    <telerik:RadSkinManager runat="server" ID="RadSkinManager1">
+        <Skins>
+            <telerik:SkinReference Path="~/MySkins" />
+        </Skins>
+    </telerik:RadSkinManager>
+    ```
 
 
 1. Set the **EnableEmbeddedSkins** property of the controls which you want to skin through the manager to **false**. Set their **Skin** property to the name of the desired custom skin.
@@ -291,21 +291,21 @@ The steps that you need to take in order to load skins by specifying a path are:
 
     * When serving the custom skin stylesheets through RadStyleSheetManager, the urls in your skin file should declare a path starting from the skin folder name, because the handler that serves them is at the root of the app:
     
-       **CSS**
-
-            .RadCalendar_Yellow .rcTitlebar
-            {
-                background: #1b1b1b 0 -1000px repeat-x url('MySkins/Yellow/Calendar/sprite.gif');
-            }
+       ```CSS
+       .RadCalendar_Yellow .rcTitlebar
+       {
+           background: #1b1b1b 0 -1000px repeat-x url('MySkins/Yellow/Calendar/sprite.gif');
+       }
+       ```
 
     * If there is **no RadStyleSheetManager** on the page, the urls in your skin file should declare a path starting from the control folder name becaues the `<link>` elements point to the actual stylesheets:
 
-        **CSS**
-
-            .RadCalendar_Yellow .rcTitlebar
-            {
-                background: #1b1b1b 0 -1000px repeat-x url('Calendar/sprite.gif');
-            }
+        ```CSS
+        .RadCalendar_Yellow .rcTitlebar
+        {
+            background: #1b1b1b 0 -1000px repeat-x url('Calendar/sprite.gif');
+        }
+        ```
 
 >note RadSkinManager does not differentiate between the different [RenderModes]({%slug controls/render-modes%}) a control can have. This means it will register the same file with the control name in all cases.
 

--- a/controls/slider/appearance-and-styling/tutorial-creating-custom-skin.md
+++ b/controls/slider/appearance-and-styling/tutorial-creating-custom-skin.md
@@ -105,28 +105,28 @@ See [Understanding the Skin CSS File]({% slug slider/appearance-and-styling/unde
 		
 	The classes that control the appearance for the selected region (to the left of the drag handle) and the track (visible on the right of the drag handle) are "rslSelectedregion" and "rslTrack" respectively. Change "rslSelectedregion" to use "Blue" for the background color.
 	
-	**CSS**
-	
-		.RadSlider_MySkin .rslHorizontal .rslSelectedregion
-		{ 
-			background:Blue none repeat scroll 0%; 
-			height:6px;
-		}
+	```CSS
+	.RadSlider_MySkin .rslHorizontal .rslSelectedregion
+	{ 
+		background:Blue none repeat scroll 0%; 
+		height:6px;
+	}
+	```
 
 1. Change the "rslTrack" style to use "AliceBlue" for the background color, border-bottom to use "Blue" color and border-top to use "DarkBlue".
 
-	**CSS**
-		
-		.RadSlider_MySkin .rslHorizontal .rslTrack
-		{ 
-			background:AliceBlue none repeat scroll 0%; 
-			border-bottom:1px solid Blue; 
-			border-top:1px solid DarkBlue; 
-			height:3px; 
-			left:12px; 
-			margin-top:6px; 
-			top:0pt;
-		}
+	```CSS
+	.RadSlider_MySkin .rslHorizontal .rslTrack
+	{ 
+		background:AliceBlue none repeat scroll 0%; 
+		border-bottom:1px solid Blue; 
+		border-top:1px solid DarkBlue; 
+		height:3px; 
+		left:12px; 
+		margin-top:6px; 
+		top:0pt;
+	}
+	```
 		
 1. Press F5 to run the application. Notice that both the graphics and background colors have changed.
 

--- a/controls/slider/getting-started/overview.md
+++ b/controls/slider/getting-started/overview.md
@@ -27,38 +27,38 @@ The following tutorial demonstrates using RadSlider to interact with the month o
 
 1. In the Properties Window, click the Events button (). Double-click the [ValueChanged]({%slug slider/server-side-programming/events%}) event to create an event handler. Replace the event handler with the code below.
 
-	**C#**
-	
-	    protected void RadSlider1_ValueChanged(object sender, EventArgs e)
-	    {
-	        Calendar1.VisibleDate = new DateTime(DateTime.Today.Year, (int)RadSlider1.Value, 1);
-	    } 
+	```C#
+	protected void RadSlider1_ValueChanged(object sender, EventArgs e)
+	{
+		Calendar1.VisibleDate = new DateTime(DateTime.Today.Year, (int)RadSlider1.Value, 1);
+	} 
+	```
 				
-	**VB**
-	
-	    Protected Sub RadSlider1_ValueChanged(ByVal sender As Object, ByVal e As EventArgs)
-	        Calendar1.VisibleDate = New DateTime(DateTime.Today.Year, DirectCast(RadSlider1.Value, Integer), 1)
-	    End Sub
+	```VB
+	Protected Sub RadSlider1_ValueChanged(ByVal sender As Object, ByVal e As EventArgs)
+		Calendar1.VisibleDate = New DateTime(DateTime.Today.Year, DirectCast(RadSlider1.Value, Integer), 1)
+	End Sub
+	```
 	
 1. Replace the Page_Load event handler with the code below:
 
-	**C#**
-	
-	    protected void Page_Load(object sender, EventArgs e)
-	    {
-	        if (!IsPostBack)
-	        {
-	            RadSlider1.Value = Calendar1.VisibleDate.Month;
-	        }
-	    } 
+	```C#
+	protected void Page_Load(object sender, EventArgs e)
+	{
+		if (!IsPostBack)
+		{
+			RadSlider1.Value = Calendar1.VisibleDate.Month;
+		}
+	} 
+	```
 				
-	**VB**
-	
-	    Protected Sub Page_Load(ByVal sender As Object, ByVal e As EventArgs)
-	        If Not IsPostBack Then
-	            RadSlider1.Value = Calendar1.VisibleDate.Month
-	        End If
-	    End Sub
+	```VB
+	Protected Sub Page_Load(ByVal sender As Object, ByVal e As EventArgs)
+		If Not IsPostBack Then
+			RadSlider1.Value = Calendar1.VisibleDate.Month
+		End If
+	End Sub
+	```
 	
 1. Press __F5__ to run the application. Drag the slider and observe the change to the Calendar. Notice that you can't drag the slider outside the minimum and maximum values of 1..12.
 

--- a/controls/socialshare/functionality/sending-via-e-mail.md
+++ b/controls/socialshare/functionality/sending-via-e-mail.md
@@ -18,44 +18,44 @@ The **RadSocialShare** control offers the ability to send a link, provided in th
 
 1. Add the `SendEmail` button ![Send Email button](images/send_e-mail_button.png) that will open the form to the `MainButtons` or `CompactButtons` collection of the **RadSocialShare**:
 
-	**ASP.NET**
-
-	    <telerik:RadSocialButton SocialNetType="SendEmail" />
+	```ASP.NET
+	<telerik:RadSocialButton SocialNetType="SendEmail" />
+	```
 
 
 
 1. Set all the properties from the `EmailSettings` inner tag - `FromEmail` (the e-mail from which the message will ultimately be received by the recipient), `SMTPServer` (the server that will be handling the requests), `UserName` (for the server) and `Password` (for the server). 
 
-	**ASP.NET**
-
-	    <telerik:RadSocialShare RenderMode="Lightweight" ID="RadSocialShare1" runat="server">
-	        <EmailSettings SMTPServer="localhost" FromEmail="my@email.com" Password="password"
-	            UserName="username" />
-	    </telerik:RadSocialShare>
+	```ASP.NET
+	<telerik:RadSocialShare RenderMode="Lightweight" ID="RadSocialShare1" runat="server">
+	    <EmailSettings SMTPServer="localhost" FromEmail="my@email.com" Password="password"
+	        UserName="username" />
+	</telerik:RadSocialShare>
+	```
 
 	Alternatively, e-mail settings can be set in the code-behind on every page load (e.g., taken from the web.config's appSettings through the `ConfigurationManager.AppSettings["yourKey"]`). 
 
 	>note The e-mail settings are private information and are not managed by the ViewState to avoid any security implications.
 
-	**C#**
-	
-		protected void Page_Init(object sender, EventArgs e)
-		{
-			RadSocialShare1.EmailSettings.SMTPServer = "localhost";
-			RadSocialShare1.EmailSettings.FromEmail = "my@email.com";
-			RadSocialShare1.EmailSettings.Password = "password";
-			RadSocialShare1.EmailSettings.UserName = "username";
-		}
+	```C#
+	protected void Page_Init(object sender, EventArgs e)
+	{
+		RadSocialShare1.EmailSettings.SMTPServer = "localhost";
+		RadSocialShare1.EmailSettings.FromEmail = "my@email.com";
+		RadSocialShare1.EmailSettings.Password = "password";
+		RadSocialShare1.EmailSettings.UserName = "username";
+	}
+	```
 		
 
-	**VB**
-	
-		Protected Sub Page_Init(sender As Object, e As EventArgs)
-			RadSocialShare1.EmailSettings.SMTPServer = "localhost"
-			RadSocialShare1.EmailSettings.FromEmail = "my@email.com"
-			RadSocialShare1.EmailSettings.Password = "password"
-			RadSocialShare1.EmailSettings.UserName = "username"
-		End Sub
+	```VB
+	Protected Sub Page_Init(sender As Object, e As EventArgs)
+		RadSocialShare1.EmailSettings.SMTPServer = "localhost"
+		RadSocialShare1.EmailSettings.FromEmail = "my@email.com"
+		RadSocialShare1.EmailSettings.Password = "password"
+		RadSocialShare1.EmailSettings.UserName = "username"
+	End Sub
+	```
 
 >note No server error will be thrown if these properties are not set, yet the e-mail will not be received as there is no server to send it. It is up to the developer to setup the mail server in each individual case according to the custom security policy, requirements and scenario of the site.
 

--- a/controls/spell/how-to/launching-on-client-side-event.md
+++ b/controls/spell/how-to/launching-on-client-side-event.md
@@ -24,23 +24,23 @@ Follow the steps below to achieve this scenario:
 
 1. Set the **RadSpell ButtonType** property to **None**. This will hide the default spellcheck button from the form:
 
-	**ASP.NET**
-
-		<telerik:radspell id="RadSpell1" runat="server" controltocheck="TextBox1" buttontype="None" /> 			
+	```ASP.NET
+	<telerik:radspell id="RadSpell1" runat="server" controltocheck="TextBox1" buttontype="None" /> 			
+	```
 
 1. Add a JavaScript function to the web page that starts the spellchecker. In this example the function is called "spellCheck()".
 
-	**JavaScript**
-
-		function spellCheck() {
-			var spell = $find('<%= RadSpell1.ClientID %>');
-			spell.startSpellCheck();
-		}	
+	```JavaScript
+	function spellCheck() {
+		var spell = $find('<%= RadSpell1.ClientID %>');
+		spell.startSpellCheck();
+	}	
+	```
 
 1. Make the TextBox control **onBlur** client-side handler call the new spellCheck() function:
 
-	**ASP.NET**
-	
-		<asp:TextBox id="TextBox1" onblur="javascript: spellCheck();" runat="server">this is a mistakr</asp:TextBox> 			
+	```ASP.NET
+	<asp:TextBox id="TextBox1" onblur="javascript: spellCheck();" runat="server">this is a mistakr</asp:TextBox> 			
+	```
 
 		

--- a/controls/splitbutton/appearance-and-styling/create-a-custom-skin.md
+++ b/controls/splitbutton/appearance-and-styling/create-a-custom-skin.md
@@ -42,16 +42,16 @@ The second file represents the actual skin of the control, and its name consists
 
 1. Add a new server declaration of **RadSplitButton** on your page, and set **Skin="MyCustomSkin"** and **EnableEmbeddedSkins="false"**:
 
-	**ASP.NET**
-
-		<telerik:RadSplitButton ID="RadSplitButton1" runat="server" EnableEmbeddedSkins="false" Skin="MyCustomSkin" />
+    ```ASP.NET
+    <telerik:RadSplitButton ID="RadSplitButton1" runat="server" EnableEmbeddedSkins="false" Skin="MyCustomSkin" />
+    ```
 
 1. Register **Button.MyCustomSkin.css** and **Menu.MyCustomSkin.css** in the head section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 
-	**ASP.NET**
-
-		<link href="Skins/MyCustomSkin/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
-		<link href="Skins/MyCustomSkin/Menu.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+    ```ASP.NET
+    <link href="Skins/MyCustomSkin/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+    <link href="Skins/MyCustomSkin/Menu.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+    ```
 
 1. Make sure the path to the files is correct; otherwise the skin will not apply;
 

--- a/controls/splitbutton/functionality/Icons/custom-icons.md
+++ b/controls/splitbutton/functionality/Icons/custom-icons.md
@@ -59,21 +59,21 @@ You can use custom font icons in **RadSplitButton** as well. To do that, follow 
 
 1. Set the custom font icon class to the **Icon.CssClass** property.
 
-	**ASP.NET**
+    ```ASP.NET
+    <telerik:RadSplitButton ID="RadSplitButton1" runat="server" Text="Button With Custom Font Icon">
+        <Icon CssClass="myCustomFontIconClass" />
+    </telerik:RadSplitButton>
 
-		<telerik:RadSplitButton ID="RadSplitButton1" runat="server" Text="Button With Custom Font Icon">
-			<Icon CssClass="myCustomFontIconClass" />
-		</telerik:RadSplitButton>
-
-		<telerik:RadSplitButton ID="RadSplitButton1" runat="server" Text="Button with Icon">
-			<Icon CssClass="myCustomFontIconClass" />
-			<ContextMenu>
-				<Items>
-					<telerik:RadMenuItem Text="Action 1" EnableImageSprite="true" SpriteCssClass="myCustomFontIconClass"></telerik:RadMenuItem>
-					<telerik:RadMenuItem Text="Action 2" EnableImageSprite="true" SpriteCssClass="myCustomFontIconClass"></telerik:RadMenuItem>
-				</Items>
-			</ContextMenu>
-		</telerik:RadSplitButton>
+    <telerik:RadSplitButton ID="RadSplitButton1" runat="server" Text="Button with Icon">
+        <Icon CssClass="myCustomFontIconClass" />
+        <ContextMenu>
+            <Items>
+                <telerik:RadMenuItem Text="Action 1" EnableImageSprite="true" SpriteCssClass="myCustomFontIconClass"></telerik:RadMenuItem>
+                <telerik:RadMenuItem Text="Action 2" EnableImageSprite="true" SpriteCssClass="myCustomFontIconClass"></telerik:RadMenuItem>
+            </Items>
+        </ContextMenu>
+    </telerik:RadSplitButton>
+    ```
 
 Sample of SplitButton with FontAwesome icons:
 

--- a/controls/splitter/appearance-and-styling/create-custom-skin.md
+++ b/controls/splitter/appearance-and-styling/create-custom-skin.md
@@ -29,28 +29,28 @@ See [Understanding the Skin CSS File]({% slug splitter/appearance-and-styling/un
 
 3. Add panes, split bar, sliding zone, and sliding panes to the splitter so that it can display various aspects of the skin. You can add controls by dragging them from the toolbox, or simply copy and paste the following declaration: 
 
-	**ASP.NET**
-	
-		<telerik:RadSplitter RenderMode="Lightweight" runat="server" ID="RadSplitter1" Orientation="Horizontal" Width="90%"
-			Height="90%">
-			<telerik:RadPane runat="server" ID="RadPane1" Height="80px">
-				<telerik:RadSlidingZone runat="server" ID="RadSlidingZone1">
-					<telerik:RadSlidingPane runat="server" Title="Pane1" ID="RadSlidingPane1" Height="50px">
-						The content of Sliding Pane 1
-					</telerik:RadSlidingPane>
-					<telerik:RadSlidingPane runat="server" Title="Pane2" ID="RadSlidingPane2" Height="50px">
-						The content of sliding pane 2
-					</telerik:RadSlidingPane>
-					<telerik:RadSlidingPane runat="server" Title="Pane3" ID="RadSlidingPane3" Height="50px">
-						The content of sliding pane 3
-					</telerik:RadSlidingPane>
-				</telerik:RadSlidingZone>
-			</telerik:RadPane>
-			<telerik:RadSplitBar runat="server" ID="RadSplitBar1" CollapseMode="Both" />
-			<telerik:RadPane runat="server" ID="RadPane2" Height="80px">
-				The content of the main pane
-			</telerik:RadPane>
-		</telerik:RadSplitter>
+	```ASP.NET
+	<telerik:RadSplitter RenderMode="Lightweight" runat="server" ID="RadSplitter1" Orientation="Horizontal" Width="90%"
+		Height="90%">
+		<telerik:RadPane runat="server" ID="RadPane1" Height="80px">
+			<telerik:RadSlidingZone runat="server" ID="RadSlidingZone1">
+				<telerik:RadSlidingPane runat="server" Title="Pane1" ID="RadSlidingPane1" Height="50px">
+					The content of Sliding Pane 1
+				</telerik:RadSlidingPane>
+				<telerik:RadSlidingPane runat="server" Title="Pane2" ID="RadSlidingPane2" Height="50px">
+					The content of sliding pane 2
+				</telerik:RadSlidingPane>
+				<telerik:RadSlidingPane runat="server" Title="Pane3" ID="RadSlidingPane3" Height="50px">
+					The content of sliding pane 3
+				</telerik:RadSlidingPane>
+			</telerik:RadSlidingZone>
+		</telerik:RadPane>
+		<telerik:RadSplitBar runat="server" ID="RadSplitBar1" CollapseMode="Both" />
+		<telerik:RadPane runat="server" ID="RadPane2" Height="80px">
+			The content of the main pane
+		</telerik:RadPane>
+	</telerik:RadSplitter>
+	```
 
 4. In the Solution Explorer, create a new "Green" directory in your project. 
 
@@ -87,73 +87,73 @@ See [Understanding the Skin CSS File]({% slug splitter/appearance-and-styling/un
 
 2. Change the border color defined by the first rule in the CSS file from "#383838" to "#389938": 
 
-	**CSS**
-	
-		.RadSplitter_Green .resizeBar, .RadSplitter_Green .slideContainerResize, 
-		.RadSplitter_Green .slideContainerResizeHorizontal, .RadSplitter_Green .resizeBarOver, 
-		.RadSplitter_Green .slideContainerResizeOver, .RadSplitter_Green .slideContainerResizeOverHorizontal, 
-		.RadSplitter_Green .resizeBarInactive, .RadSplitter_Green .resizeBarHorizontal, 
-		.RadSplitter_Green .resizeBarOverHorizontal, .RadSplitter_Green .resizeBarInactiveHorizontal, 
-		.RadSplitter_Green .pane, .RadSplitter_Green .paneHorizontal
-		{
-			border: 1px solid #389938;
-		}
+	```CSS
+	.RadSplitter_Green .resizeBar, .RadSplitter_Green .slideContainerResize, 
+	.RadSplitter_Green .slideContainerResizeHorizontal, .RadSplitter_Green .resizeBarOver, 
+	.RadSplitter_Green .slideContainerResizeOver, .RadSplitter_Green .slideContainerResizeOverHorizontal, 
+	.RadSplitter_Green .resizeBarInactive, .RadSplitter_Green .resizeBarHorizontal, 
+	.RadSplitter_Green .resizeBarOverHorizontal, .RadSplitter_Green .resizeBarInactiveHorizontal, 
+	.RadSplitter_Green .pane, .RadSplitter_Green .paneHorizontal
+	{
+		border: 1px solid #389938;
+	}
+	```
 
 3. Locate the rule for the split bars and resizable borders on sliding panes. This has the same selectors as the rule for the borders that you just changed, except that there are no selectors for the panes of the splitter. Change the background color from "#383838" to "#389938", so that the resize bars have the same color as the borders: 
 
-	**CSS**
-	
-		.RadSplitter_Green .resizeBar, .RadSplitter_Green .slideContainerResize, 
-		.RadSplitter_Green .slideContainerResizeHorizontal, 
-		.RadSplitter_Green .resizeBarOver, .RadSplitter_Green .slideContainerResizeOver, 
-		.RadSplitter_Green .slideContainerResizeOverHorizontal, 
-		.RadSplitter_Green .resizeBarInactive, .RadSplitter_Green .resizeBarHorizontal, 
-		.RadSplitter_Green .resizeBarOverHorizontal, 
-		.RadSplitter_Green .resizeBarInactiveHorizontal
-		{
-			padding: 0;
-			background: #389938;
-			font-size: 1px;
-			text-align: center;
-		}
+	```CSS
+	.RadSplitter_Green .resizeBar, .RadSplitter_Green .slideContainerResize, 
+	.RadSplitter_Green .slideContainerResizeHorizontal, 
+	.RadSplitter_Green .resizeBarOver, .RadSplitter_Green .slideContainerResizeOver, 
+	.RadSplitter_Green .slideContainerResizeOverHorizontal, 
+	.RadSplitter_Green .resizeBarInactive, .RadSplitter_Green .resizeBarHorizontal, 
+	.RadSplitter_Green .resizeBarOverHorizontal, 
+	.RadSplitter_Green .resizeBarInactiveHorizontal
+	{
+		padding: 0;
+		background: #389938;
+		font-size: 1px;
+		text-align: center;
+	}
+	```
 
 4. Locate the rule that applies only when the mouse is over the split bar or resizable border. This specifies the color when the mouse is over a resizable border or split bar. Change the background color from "#383838" to "#38ff38": 
 
-	**CSS**
-	
-		.RadSplitter_Green .resizeBarOver, .RadSplitter_Green .resizeBarOverHorizontal, 
-		.RadSplitter_Green .slideContainerResizeOver, 
-		.RadSplitter_Green .slideContainerResizeOverHorizontal
-		{
-			background: #38ff38;
-		}
+	```CSS
+	.RadSplitter_Green .resizeBarOver, .RadSplitter_Green .resizeBarOverHorizontal, 
+	.RadSplitter_Green .slideContainerResizeOver, 
+	.RadSplitter_Green .slideContainerResizeOverHorizontal
+	{
+		background: #38ff38;
+	}
+	```
 
 
 5. While the user is dragging a split bar or resizable border, the position of the dragged split bar or border is rendered with a semi-opaque image. For split bars, this image has the **.helperBarDrag** or **.helperBarDragHorizontal** class applied. For resizable borders, this image has the .helperBarSlideDrag or .helperBarSlideDragHorizontal class applied. Locate the selector for these classes, and change the background color from "#ccc" to "#cfa": 
 
-	**CSS**
-	
-		.RadSplitter_Green .helperBarDrag, .RadSplitter_Green .helperBarDragHorizontal, 
-		.RadSplitter_Green .helperBarSlideDrag, .RadSplitter_Green .helperBarSlideDragHorizontal
-		{
-			font-size: 1px;
-			background-color: #cfa;
-			filter: progid:DXImageTransform.Microsoft.Alpha(opacity=60);
-			opacity: 0.6;
-		}
+	```CSS
+	.RadSplitter_Green .helperBarDrag, .RadSplitter_Green .helperBarDragHorizontal, 
+	.RadSplitter_Green .helperBarSlideDrag, .RadSplitter_Green .helperBarSlideDragHorizontal
+	{
+		font-size: 1px;
+		background-color: #cfa;
+		filter: progid:DXImageTransform.Microsoft.Alpha(opacity=60);
+		opacity: 0.6;
+	}
+	```
 
 6. When the user tries to drag a split bar or resizable border too far, so that the resulting change would cause an invalid layout (for example, causing a pane to exceed its maximum size), the image of the split bar or border changes its appearance to provide feedback to the user that it is not moving because of a problem. When this occurs, the drag image has the **.helperBarError**, **.helperBarSlideError**, or **.helperBarErrorHorizontal** class applied (depending on whether it is a vertical split bar, resizable border, or horizontal split bar being dragged). Locate these selectors, and change the color of the drag image from "#f60" to "red" when an error condition arises: 
 
-	**CSS**
-	
-		.RadSplitter_Green .helperBarError, .RadSplitter_Green .helperBarSlideError, 
-		.RadSplitter_Green .helperBarErrorHorizontal
-		{
-			font-size: 1px;
-			background-color: red;
-			filter: progid:DXImageTransform.Microsoft.Alpha(opacity=60);
-			opacity: 0.6;
-		}
+	```CSS
+	.RadSplitter_Green .helperBarError, .RadSplitter_Green .helperBarSlideError, 
+	.RadSplitter_Green .helperBarErrorHorizontal
+	{
+		font-size: 1px;
+		background-color: red;
+		filter: progid:DXImageTransform.Microsoft.Alpha(opacity=60);
+		opacity: 0.6;
+	}
+	```
 
 7. Locate the rules with the selectors **.RadSplitter_Green .resizeBarHorizontal** and **.RadSplitter_Green .resizeBar** that assign a background image to the split bar (either "Splitter/splitbarBg.gif" or "Splitter/splitbarBgVertial.gif"). Delete these rules, so that the background color you assigned previously can show. 
 
@@ -167,80 +167,80 @@ See [Understanding the Skin CSS File]({% slug splitter/appearance-and-styling/un
 
 1. The **RadSlidingZone** control is rendered using a &lt;table&gt; element with the **.slideZone** class applied. Locate the selector for this class, and change the background color from "white" to "#f5ffef": 
 
-	**CSS**
-	
-		.RadSplitter_Green .slideZone
-		{
-			background: #f5ffef;
-		}
+	```CSS
+	.RadSplitter_Green .slideZone
+	{
+		background: #f5ffef;
+	}
+	```
 		
 2. The portion of the sliding zone that holds the sliding zone tabs has the **.tabsContainer** class applied. If the **SlideDirection** is "Bottom", the **.bottom** class is applied as well. Locate the selectors for these classes that are used to add a border to the sliding zone, and change the border color from "#383838" to "#389938": 
 
-	**CSS**
-
-		.RadSplitter_Green .tabsContainer
-		{
-			border-right: 1px solid #389938;
-		}
-		.RadSplitter_Green .tabsContainer.bottom
-		{
-			border-bottom: 1px solid #389938;
-			border-right: 0;
-		}	
+	```CSS
+	.RadSplitter_Green .tabsContainer
+	{
+		border-right: 1px solid #389938;
+	}
+	.RadSplitter_Green .tabsContainer.bottom
+	{
+		border-bottom: 1px solid #389938;
+		border-right: 0;
+	}	
+	```
 
 3. Locate the selector **.RadSplitter_Green .tabsContainer div**. This rule affects all the &lt;div&gt; elements inside the sliding zone, which are the rendered images of portions of the title bar. Change the color attribute from "#383838" to "#389938" to change the font color of the title: 
 
-	**CSS**
-	
-		.RadSplitter_Green .tabsContainer div
-		{
-			overflow: hidden;
-			cursor: default;
-			text-align: center;
-			font-size: 1px;
-			color: #389938;
-			padding: 6px 0;
-			width: 21px;
-			height: auto;
-			border-bottom: 1px solid #313131;
-		}
+	```CSS
+	.RadSplitter_Green .tabsContainer div
+	{
+		overflow: hidden;
+		cursor: default;
+		text-align: center;
+		font-size: 1px;
+		color: #389938;
+		padding: 6px 0;
+		width: 21px;
+		height: auto;
+		border-bottom: 1px solid #313131;
+	}
+	```
 
 4. When a tab in the sliding zone is expanded to show its sliding pane, it has the **.paneTabContainerExpanded** or **.paneTabContainerExpandedHorizontal** class applied. Locate the selectors **.RadSplitter_Green .tabsContainer.paneTabContainerExpanded**, **.RadSplitter_Green .tabsContainer .paneTabContainerExpandedHorizontal**, and change the background and foreground colors from "#323232" and "#fff" to "#32ff32" and "green": 
 
-	**CSS**
-	
-		.RadSplitter_Green .tabsContainer .paneTabContainerExpanded, 
-		.RadSplitter_Green .tabsContainer .paneTabContainerExpandedHorizontal
-		{
-			background: #32ff32;
-			color: green;
-		}
+	```CSS
+	.RadSplitter_Green .tabsContainer .paneTabContainerExpanded, 
+	.RadSplitter_Green .tabsContainer .paneTabContainerExpandedHorizontal
+	{
+		background: #32ff32;
+		color: green;
+	}
+	```
 
 
 5. When a sliding pane is docked, its tab in the sliding zone has the **.paneTabContainerDocked** or **.paneTabContainerDockedHorizontal** class applied. Locate the selectors **.RadSplitter_Green .paneTabContainerDocked** and **.RadSplitterGreen .paneTabContainerDockedHorizontal**, and change the background from "#e4e4e4" to "#32dd32": 
 
-	**CSS**
-	
-		.RadSplitter_Green .paneTabContainerDocked, 
-		.RadSplitter_Green .paneTabContainerDockedHorizontal
-		{
-			background: #32dd32;
-		}
+	```CSS
+	.RadSplitter_Green .paneTabContainerDocked, 
+	.RadSplitter_Green .paneTabContainerDockedHorizontal
+	{
+		background: #32dd32;
+	}
+	```
 
 6. Each tab in the sliding zone has either the **.paneTabContainer**, **.paneTabContainerExpanded**, or **.paneTabContainerDocked** class applied. Its immediate container has the **.top**, **.bottom**, **.left**, or **.right** class applied, depending on the **SlideDirection** property. The CSS file contains a number of selectors that combine these classes to provide the borders of individual tabs. Locate these selectors and change the border color from "#c3c3c3" to "#389938". The new rule is shown for the selectors that include the **.bottom** class: 
 
-	**CSS**
-	
-		.RadSplitter_Green .bottom .paneTabContainer, 
-		.RadSplitter_Green .bottom .paneTabContainerExpanded, 
-		.RadSplitter_Green .bottom .paneTabContainerDocked
-		{
-			border-right: solid 1px #389938;
-			border-left: 0;
-			float: left;
-			padding: 0 6px;
-			width: auto;
-		}
+	```CSS
+	.RadSplitter_Green .bottom .paneTabContainer, 
+	.RadSplitter_Green .bottom .paneTabContainerExpanded, 
+	.RadSplitter_Green .bottom .paneTabContainerDocked
+	{
+		border-right: solid 1px #389938;
+		border-left: 0;
+		float: left;
+		padding: 0 6px;
+		width: auto;
+	}
+	```
 
 1. Run the application to see the effect of your changes: 
 
@@ -252,38 +252,38 @@ See [Understanding the Skin CSS File]({% slug splitter/appearance-and-styling/un
 
 1. The **RadSlidingPane** control is rendered using a &lt;table&gt; element with the **.slideContainer** class applied. Its header is a row in the table with the **.slideHeader** or **.slideHeaderDocked** class applied. Locate the selectors for these classes. Replace the background image (slideHeader.gif) with a solid green background: 
 
-	**CSS**
-			
-		.RadSplitter_Green .slideHeader, .RadSplitter_Green .slideHeaderDocked
-		{
-			background: green;
-			color: #fff;
-			text-transform: uppercase;
-		}
+	```CSS
+	.RadSplitter_Green .slideHeader, .RadSplitter_Green .slideHeaderDocked
+	{
+		background: green;
+		color: #fff;
+		text-transform: uppercase;
+	}
+	```
 
 2. Locate the paired selectors for **.RadSplitter_Green .slideContainerResize** and **.RadSplitter_Green .slideContainerResizeHorizontal**, and the paired selectors for **.RadSplitter_Green .slideContainerResizeOver** and **.RadSplitter_Green .slideContainerResizeOverHorizontal**. These two rules set a background color for the resizable border of the sliding pane. Change the color to match the settings you applied previously to the split bars: 
 
-	**CSS**
-
-		.RadSplitter_Green .slideContainerResize, 
-		.RadSplitter_Green .slideContainerResizeHorizontal
-		{
-			background: #389938 none;
-		}
-		.RadSplitter_Green .slideContainerResizeOver, 
-		.RadSplitter_Green .slideContainerResizeOverHorizontal
-		{
-			background: #38ff38 none;
-		}
+	```CSS
+	.RadSplitter_Green .slideContainerResize, 
+	.RadSplitter_Green .slideContainerResizeHorizontal
+	{
+		background: #389938 none;
+	}
+	.RadSplitter_Green .slideContainerResizeOver, 
+	.RadSplitter_Green .slideContainerResizeOverHorizontal
+	{
+		background: #38ff38 none;
+	}
+	```
 
 3. Locate the selector **.RadSplitter_Green .slideTitleContainer**. This class is applied to the title bar of the sliding pane. Change the background-color from "#f7f7f7" to "Green" and remove the background attribute that loads a background image: 
 
-	**CSS**
-	
-		.RadSplitter_Green .slideTitleContainer
-		{
-			background-color: Green;
-		}
+	```CSS
+	.RadSplitter_Green .slideTitleContainer
+	{
+		background-color: Green;
+	}
+	```
 
 4. Run the application to see the effect of your changes: 
 

--- a/controls/splitter/getting-started/migrating-from-radsplitter-classic-to-radsplitter-for-asp.net-ajax.md
+++ b/controls/splitter/getting-started/migrating-from-radsplitter-classic-to-radsplitter-for-asp.net-ajax.md
@@ -22,35 +22,35 @@ To migrate a Web application from **RadSplitter** "Classic" to **RadSplitter** f
 
 1. Replace the classic **RadSplitter** directive
 
-	**ASP.NET**
-	
-		<%@ Register Assembly="RadSplitter.Net2" Namespace="Telerik.WebControls" TagPrefix="RadSpl" %>
+	```ASP.NET
+	<%@ Register Assembly="RadSplitter.Net2" Namespace="Telerik.WebControls" TagPrefix="RadSpl" %>
+	```
 
 	with the new one of **RadSplitter** for ASP.NET AJAX:
 
-	**ASP.NET**
-	
-		<%@ Register Assembly="Telerik.Web.UI" Namespace="Telerik.Web.UI" TagPrefix="telerik" %>
+	```ASP.NET
+	<%@ Register Assembly="Telerik.Web.UI" Namespace="Telerik.Web.UI" TagPrefix="telerik" %>
+	```
 
 1. Replace the classic **RadSplitter** controls declarations:
 
-	**ASP.NET**
-	     
-		<RadSpl:RadSplitter id="RadSplitter1" runat="server"/>
-		<RadSpl:RadPane id="RadPane1" runat="server"/>
-		<RadSpl:RadSplitBar id="RadSplitBar1" runat="server"/>
-		<RadSpl:RadSlidingZone id="RadSliding1" runat="server"/>
-		<RadSpl:RadSlidingPane id="RadSlidingPane1" runat="server"/>
+	```ASP.NET
+	<RadSpl:RadSplitter id="RadSplitter1" runat="server"/>
+	<RadSpl:RadPane id="RadPane1" runat="server"/>
+	<RadSpl:RadSplitBar id="RadSplitBar1" runat="server"/>
+	<RadSpl:RadSlidingZone id="RadSliding1" runat="server"/>
+	<RadSpl:RadSlidingPane id="RadSlidingPane1" runat="server"/>
+	```
 				
 	with the new **RadSplitter** declarations:
 
-	**ASP.NET**
-	     
-		<telerik:RadSplitter RenderMode="Lightweight" id="RadSplitter1" runat="server"/>
-		<telerik:RadPane id="RadPane1" runat="server"/>
-		<telerik:RadSplitBar id="RadSplitBar1" runat="server"/>
-		<telerik:RadSlidingZone id="RadSlidingZone1" runat="server"/>
-		<telerik:RadSlidingPane id="RadSlidingPane1" runat="server"/>
+	```ASP.NET
+	<telerik:RadSplitter RenderMode="Lightweight" id="RadSplitter1" runat="server"/>
+	<telerik:RadPane id="RadPane1" runat="server"/>
+	<telerik:RadSplitBar id="RadSplitBar1" runat="server"/>
+	<telerik:RadSlidingZone id="RadSlidingZone1" runat="server"/>
+	<telerik:RadSlidingPane id="RadSlidingPane1" runat="server"/>
+	```
 
 
 

--- a/controls/splitter/how-to/referencing-the-external-content-of-a-pane.md
+++ b/controls/splitter/how-to/referencing-the-external-content-of-a-pane.md
@@ -22,23 +22,23 @@ To get a reference to the page that contains the **RadSplitter** control (the pa
 
 1. Inside the parent page, define JavaScript functions that return a reference to any controls in the parent page that the content page needs to access:
 
-	**JavaScript**
-
-		function GetRadSplitter()
-		{
-			return $find("<%= RadSplitter1.ClientID %>");
-		}
+	```JavaScript
+	function GetRadSplitter()
+	{
+		return $find("<%= RadSplitter1.ClientID %>");
+	}
+	```
 
 
 1. Inside the content page, use the **parent** keyword to reference the parent page, and then call the functions you defined previously to access the controls on the parent page:
 
-	**JavaScript**
-	
-	        //obtain reference to the parent page
-	        var splitterPageWnd = window.parent;
-	        //call a method from the parent page
-	        var splitterObject = splitterPageWnd.GetRadSplitter();
-	        //...
+	```JavaScript
+	//obtain reference to the parent page
+	var splitterPageWnd = window.parent;
+	//call a method from the parent page
+	var splitterObject = splitterPageWnd.GetRadSplitter();
+	//...
+	```
 
 		
 		

--- a/controls/stepper/client-side-programming/overview.md
+++ b/controls/stepper/client-side-programming/overview.md
@@ -22,17 +22,17 @@ RadStepper is a server-side wrapper over the Kendo UI Stepper Widget. Thus, it e
 
 * Use the `get_kendoWidget()` method of the MS AJAX wrapper:
 
-    **JavaScript**
-
-        var stepperObject  = $find("<%=RadStepper1.ClientID %>"); //the standard script control object
-        var kendoStepper = stepperObject.get_kendoWidget(); //the Kendo widget
+    ```JavaScript
+    var stepperObject  = $find("<%=RadStepper1.ClientID %>"); //the standard script control object
+    var kendoStepper = stepperObject.get_kendoWidget(); //the Kendo widget
+    ```
 
 
 * Get the Kendo Widget in its usual way. Make sure to use the `$telerik._kendo.jQuery` reference that has the Kendo widget data:
 
-    **JavaScript**
-    
-        var kendoStepper = $telerik._kendo.jQuery("#<%=RadStepper1.ClientID %>").data("kendoStepper");
+    ```JavaScript
+    var kendoStepper = $telerik._kendo.jQuery("#<%=RadStepper1.ClientID %>").data("kendoStepper");
+    ```
 
 >important As of the 2026 Q1 release, Kendo jQuery widget plugins and data are registered on `$telerik._kendo.jQuery` — a different jQuery instance from `$telerik.$`. If you use `$telerik.$` with `.data("kendoXxx")`, it will return `undefined`. Always use `$telerik._kendo.jQuery` when accessing the underlying Kendo widget via the `.data()` method. The recommended approach, however, is to use the `get_kendoWidget()` method shown above. 
 

--- a/controls/switch/getting-started.md
+++ b/controls/switch/getting-started.md
@@ -14,81 +14,81 @@ The following tutorial demonstrates how to set up a page with a **RadSwitch** co
 
 1. In the default page of a new ASP.NET AJAX-enabled Web Application add a **RadSwitch** control:
 
-	**ASP.NET**	
-	
-		<telerik:RadSwitch ID="RadSwitch1" runat="server">
-		</telerik:RadSwitch>
+    ```ASP.NET
+    <telerik:RadSwitch ID="RadSwitch1" runat="server">
+    </telerik:RadSwitch>
+    ```
 
 1. Set the `Text` of the RadSwitch Toggle states (unless you want them empty)
 
-	**ASP.NET**
-
-        <telerik:RadSwitch runat="server" ID="RadSwitch1" Value="0" CommandArgument="arg1">
-            <ToggleStates>
-                <ToggleStateOff Text="No" />
-                <ToggleStateOn Text="Yes" />
-            </ToggleStates>
-        </telerik:RadSwitch>
+    ```ASP.NET
+    <telerik:RadSwitch runat="server" ID="RadSwitch1" Value="0" CommandArgument="arg1">
+        <ToggleStates>
+            <ToggleStateOff Text="No" />
+            <ToggleStateOn Text="Yes" />
+        </ToggleStates>
+    </telerik:RadSwitch>
+    ```
         
 1. Add a Label to show a text associated with **RadSwitch**
 
-	**ASP.NET**
-
-        <telerik:RadLabel ID="switchLabel" runat="server" AssociatedControlID="RadSwitch1" Text="I agree to the Terms & Conditions."></telerik:RadLabel>
+    ```ASP.NET
+    <telerik:RadLabel ID="switchLabel" runat="server" AssociatedControlID="RadSwitch1" Text="I agree to the Terms & Conditions."></telerik:RadLabel>
+    ```
 
 
 1. To hook to the **OnCheckedChanged** server-side event of **RadSwitch** add an attribute to the main control tag and add the method signature:
 
-	**ASP.NET**
+    ```ASP.NET
+    <telerik:RadSwitch runat="server" ID="RadSwitch1" Value="0" CommandArgument="arg1" OnCheckedChanged="RadSwitch1_CheckedChanged">
+        <ToggleStates>
+            <ToggleStateOff Text="No" />
+            <ToggleStateOn Text="Yes" />
+        </ToggleStates>
+    </telerik:RadSwitch>
+    ```
 
-        <telerik:RadSwitch runat="server" ID="RadSwitch1" Value="0" CommandArgument="arg1" OnCheckedChanged="RadSwitch1_CheckedChanged">
-            <ToggleStates>
-                <ToggleStateOff Text="No" />
-                <ToggleStateOn Text="Yes" />
-            </ToggleStates>
-        </telerik:RadSwitch>
+    ```C#
+    protected void RadSwitch1_CheckedChanged(object sender, EventArgs e)
+    {
+	
+    }
+    ```
 
-	**C#**
-	
-		protected void RadSwitch1_CheckedChanged(object sender, EventArgs e)
-		{
-	
-		}
-
-	**VB**
-	
-		Protected Sub RadSwitch1_CheckedChanged(ByVal sender As Object, ByVal e As EventArgs)
-		End Sub
+    ```VB
+    Protected Sub RadSwitch1_CheckedChanged(ByVal sender As Object, ByVal e As EventArgs)
+    End Sub
+    ```
 
 1. Add a Label control to write the information to:
 
-	**ASP.NET**
-
-        <telerik:RadLabel ID="Label1" runat="server"></telerik:RadLabel>
+    ```ASP.NET
+    <telerik:RadLabel ID="Label1" runat="server"></telerik:RadLabel>
+    ```
 
 1. Use the **CheckedChanged** event handler to write information about the switch properties:
 	
-	**C#**
+    ```C#
+    protected void RadSwitch1_CheckedChanged(object sender, EventArgs e)
+    {
+        var switchObj = sender as RadSwitch;
+        var currentText = (bool)switchObj.Checked ? switchObj.ToggleStates.ToggleStateOn.Text : switchObj.ToggleStates.ToggleStateOff.Text;
+        string data = string.Format("current text: {0}, current value {1}, current command argument: {2}, checked: {3}",
 
-        protected void RadSwitch1_CheckedChanged(object sender, EventArgs e)
-        {
-            var switchObj = sender as RadSwitch;
-            var currentText = (bool)switchObj.Checked ? switchObj.ToggleStates.ToggleStateOn.Text : switchObj.ToggleStates.ToggleStateOff.Text;
-            string data = string.Format("current text: {0}, current value {1}, current command argument: {2}, checked: {3}",
-    
-                                        currentText, switchObj.Value, switchObj.CommandArgument, switchObj.Checked);
-            Label1.Text = data;
-        }
+                                    currentText, switchObj.Value, switchObj.CommandArgument, switchObj.Checked);
+        Label1.Text = data;
+    }
+    ```
 
 
-	**VB**
-	
-        Protected Sub RadSwitch1_CheckedChanged(ByVal sender As Object, ByVal e As EventArgs)
-            Dim switchObj = TryCast(sender, RadSwitch)
-            Dim currentText = If(CBool(switchObj.Checked), switchObj.ToggleStates.ToggleStateOn.Text, switchObj.ToggleStates.ToggleStateOff.Text)
-            Dim data As String = String.Format("current text: {0}, current value {1}, current command argument: {2}, checked: {3}", currentText, switchObj.Value, switchObj.CommandArgument, switchObj.Checked)
-            Label1.Text = data
-        End Sub
+    ```VB
+    Protected Sub RadSwitch1_CheckedChanged(ByVal sender As Object, ByVal e As EventArgs)
+        Dim switchObj = TryCast(sender, RadSwitch)
+        Dim currentText = If(CBool(switchObj.Checked), switchObj.ToggleStates.ToggleStateOn.Text, switchObj.ToggleStates.ToggleStateOff.Text)
+        Dim data As String = String.Format("current text: {0}, current value {1}, current command argument: {2}, checked: {3}", currentText, switchObj.Value, switchObj.CommandArgument, switchObj.Checked)
+        Label1.Text = data
+    End Sub
+    ```
 
 
 ## See Also

--- a/controls/switch/mobile-support/render-modes.md
+++ b/controls/switch/mobile-support/render-modes.md
@@ -21,19 +21,19 @@ There are two ways to configure the rendering mode of the controls:
 
 * The **RenderMode property** in the markup or in the code-behind that can be used for a particular instance:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadSwitch ID="RadSwitch1" runat="server" RenderMode="Lightweight">
+	</telerik:RadSwitch>
+	```
 
-		<telerik:RadSwitch ID="RadSwitch1" runat="server" RenderMode="Lightweight">
-		</telerik:RadSwitch>
 
+	```C#
+	RadSwitch1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	```
 
-	**C#**
-
-		RadSwitch1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-
-	**VB**
-
-		RadSwitch1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```VB
+	RadSwitch1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```
 
 
 * A **global setting in the web.config** file that will affect the entire application, unless a concrete value is specified for a given control instance:

--- a/controls/tagcloud/appearance-and-styling/creating-a-custom-skin.md
+++ b/controls/tagcloud/appearance-and-styling/creating-a-custom-skin.md
@@ -38,10 +38,10 @@ In order to explain better the CSS classes of **RadTagCloud**, we will use both 
 
 1. Put a new server declaration of RadTagCloud on your page, and set **Skin="MyCustomSkin"**, **EnableEmbeddedSkins="false"** and **EnableEmbeddedBasestylesheet="false"**:
 
-	**ASP.NET**
-	
-		<telerik:RadTagCloud RenderMode="Lightweight" Id="RadTagCloud1" runat="server" Skin="MyCustomSkin" EnableEmbeddedSkins="false"
-			EnableEmbeddedBasestylesheet="false"> </telerik:RadTagCloud>
+	```ASP.NET
+	<telerik:RadTagCloud RenderMode="Lightweight" Id="RadTagCloud1" runat="server" Skin="MyCustomSkin" EnableEmbeddedSkins="false"
+		EnableEmbeddedBasestylesheet="false"> </telerik:RadTagCloud>
+	```
 
 1. Register **TagCloud.css** and **TagCloud.MyCustomSkin.css** in the <head>...</head> section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:**Important:** Make sure the path to the files is correct, otherwise the skin will not apply.
 

--- a/controls/tagcloud/data-binding/binding-to-web-service-or-wcf-service.md
+++ b/controls/tagcloud/data-binding/binding-to-web-service-or-wcf-service.md
@@ -174,58 +174,58 @@ End Class
 	* Set the Method sub-property to the name of the method of the Web service that supplies child items.
 	* Set the UseHttpGet sub-property to True to change the default HTTP method (POST).
 	
-	**ASP.NET**
-	
-		<telerik:RadTagCloud RenderMode="Lightweight" ID="RadTagCloud1" runat="server" OnClientItemsRequesting="itemsRequesting" 
-			OnClientItemsRequested="itemsRequested"	OnClientItemsRequestFailed="itemsRequestFailed">
-			<WebServiceSettings Path="VehiclesWeightByRating.asmx" Method="GetRadTagCloudItems" />
-		</telerik:RadTagCloud>
+	```ASP.NET
+	<telerik:RadTagCloud RenderMode="Lightweight" ID="RadTagCloud1" runat="server" OnClientItemsRequesting="itemsRequesting" 
+		OnClientItemsRequested="itemsRequested"	OnClientItemsRequestFailed="itemsRequestFailed">
+		<WebServiceSettings Path="VehiclesWeightByRating.asmx" Method="GetRadTagCloudItems" />
+	</telerik:RadTagCloud>
+	```
 
 2. When the WebServiceSettings property is set, an empty context request will be initiated automatically. You can trigger request to the service by calling the *requestItems()* client-side method. This method has a single parameter, which is sent as an argument to the Web service method.
 >important It is important to know that all current items will be removed, before the new ones are populated.
 >
 
-	**JavaScript**
-	
-		function clientFunction()
-		{
-			//...
-			var context = "some value";
-			tagCloud.requestItems(context);
-			//...
-		}	
+	```JavaScript
+	function clientFunction()
+	{
+		//...
+		var context = "some value";
+		tagCloud.requestItems(context);
+		//...
+	}	
+	```
 
 3. Optionally, set the **OnClientItemsRequesting** property to a client-side event handler that passes context information to the Web service. The Web service can use this context information to determine what child items to return or what properties to set on those child items.
 
-	**JavaScript**
-	
-		//Fired before the request is sent to the Web Service
-		function itemsRequesting(sender, args)
-		{
-			//If you want to cancel the request use
-			//args.set_cancel(true);
+	```JavaScript
+	//Fired before the request is sent to the Web Service
+	function itemsRequesting(sender, args)
+	{
+		//If you want to cancel the request use
+		//args.set_cancel(true);
 
-			//The args.get_context()/args.set_context(value) methods get/set the parameter which will be sent to the Web Service.
-			var context = args.get_context();
-		}
+		//The args.get_context()/args.set_context(value) methods get/set the parameter which will be sent to the Web Service.
+		var context = args.get_context();
+	}
+	```
 
 4. Optionally, set the **OnClientItemsRequested** and **OnClientItemsRequestFailed** properties to client-side event handlers that respond when the Web service has successfully loaded child items or when the Web service has generated an error while trying to service the item request, respectively.
 
-	**JavaScript**
-	
-		//Fired when the items are successfully loaded.
-		function itemsRequested(sender, args)
-		{
-			//...
-		}
+	```JavaScript
+	//Fired when the items are successfully loaded.
+	function itemsRequested(sender, args)
+	{
+		//...
+	}
 
-		//Fired when the request for the items fails.
-		function itemsRequestFailed(sender, args)
-		{
-			// Disable the notifying error alert.
-			args.set_cancelErrorAlert(true);
-			//...
-		}
+	//Fired when the request for the items fails.
+	function itemsRequestFailed(sender, args)
+	{
+		// Disable the notifying error alert.
+		args.set_cancelErrorAlert(true);
+		//...
+	}
+	```
 
 5. To use the integrated WebService support of **RadTagCloud**, the WebService should have the following signature:
 
@@ -289,20 +289,20 @@ For a live example of using a Web service to populate items, see the [Web Servic
 	* Set the Path sub-property to the URL for the Web service.
 	* Set the Method sub-property to the name of the method of the WCF Web service that supplies child items.
 
-	**ASP.NET**
-	
-		<telerik:RadTagCloud RenderMode="Lightweight" ID="RadTagCloud1" runat="server"
-			OnClientItemsRequesting="itemsRequesting"
-			OnClientItemsRequested="itemsRequested"
-			OnClientItemsRequestFailed="itemsRequestFailed">
-			<WebServiceSettings Path="TagCloudWcfService.svc" Method="GetRadTagCloudItems" />
-		</telerik:RadTagCloud>
+	```ASP.NET
+	<telerik:RadTagCloud RenderMode="Lightweight" ID="RadTagCloud1" runat="server"
+		OnClientItemsRequesting="itemsRequesting"
+		OnClientItemsRequested="itemsRequested"
+		OnClientItemsRequestFailed="itemsRequestFailed">
+		<WebServiceSettings Path="TagCloudWcfService.svc" Method="GetRadTagCloudItems" />
+	</telerik:RadTagCloud>
+	```
 
 	where the WCF WebService must be in the website, e.g.:
 
-	**ASP.NET**
-	
-		<%@ ServiceHost Language="C#" Debug="true" Service="TagCloudWcfService" CodeBehind="~/App_Code/TagCloudWcfService.cs" %>
+	```ASP.NET
+	<%@ ServiceHost Language="C#" Debug="true" Service="TagCloudWcfService" CodeBehind="~/App_Code/TagCloudWcfService.cs" %>
+	```
 
 
 2. When the WebServiceSettings property is set, an empty context request will be initiated automatically. You can trigger request to the service by calling the *requestItems()* client-side method. This method has a single parameter, which is sent as an argument to the Web service method.
@@ -310,48 +310,48 @@ For a live example of using a Web service to populate items, see the [Web Servic
 
 	>note Passing a value to a WCF service requires creating an object that will hold the data. This object will be serialized automatically. This object is received by the WCF WebService as a parameter of type IDictionary and you can access the value of the object you provided according to its name.
 
-	**JavaScript**
-
-		function clientFunction()
-		{
-			//...
-			var context = { minUnitPrice: "500" };
-			tagCloud.requestItems(context);
-			//...
-		}
+	```JavaScript
+	function clientFunction()
+	{
+		//...
+		var context = { minUnitPrice: "500" };
+		tagCloud.requestItems(context);
+		//...
+	}
+	```
 
 
 3. Optionally, set the **OnClientItemsRequesting** property to a client-side event handler that passes context information to the Web service. The Web service can use this context information to determine what child items to return or what properties to set on those child items. Note that setting the context requires an object as shown above.
 
-	**JavaScript**
-	
-		//Fired before the request is sent to the Web Service
-		function itemsRequesting(sender, args)
-		{
-			//If you want to cancel the request use
-			//args.set_cancel(true);
+	```JavaScript
+	//Fired before the request is sent to the Web Service
+	function itemsRequesting(sender, args)
+	{
+		//If you want to cancel the request use
+		//args.set_cancel(true);
 
-			//The args.get_context()/args.set_context(value) methods get/set the parameter which will be sent to the Web Service.
-			var context = args.get_context();
-		}
+		//The args.get_context()/args.set_context(value) methods get/set the parameter which will be sent to the Web Service.
+		var context = args.get_context();
+	}
+	```
 
 4. Optionally, set the **OnClientItemsRequested** and **OnClientItemsRequestFailed** properties to client-side event handlers that respond when the Web service has successfully loaded child items or when the Web service has generated an error while trying to service the item request, respectively.
 
-	**JavaScript**
-	
-		//Fired when the items are successfully loaded.
-		function itemsRequested(sender, args)
-		{
-			//...
-		}
+	```JavaScript
+	//Fired when the items are successfully loaded.
+	function itemsRequested(sender, args)
+	{
+		//...
+	}
 
-		//Fired when the request for the items fails.
-		function itemsRequestFailed(sender, args)
-		{
-			// Disable the notifing error alert.
-			args.set_cancelErrorAlert(true);
-			//...
-		}
+	//Fired when the request for the items fails.
+	function itemsRequestFailed(sender, args)
+	{
+		// Disable the notifing error alert.
+		args.set_cancelErrorAlert(true);
+		//...
+	}
+	```
 
 5. To use the integrated WCF WebService support of **RadTagCloud**, the WCF WebService should have the following signature:
 

--- a/controls/timeline/client-side-programming/overview.md
+++ b/controls/timeline/client-side-programming/overview.md
@@ -22,16 +22,16 @@ RadTimeline is a server-side wrapper over the Kendo UI Timeline Widget. Thus, it
 
 * Use the `get_kendoWidget()` method of the MS AJAX wrapper:
 
-    **JavaScript**
-    
-        var timelineObject  = $find("<%=RadTimeline1.ClientID %>"); //the standard script control object
-        var kendoTimeline = timelineObject.get_kendoWidget(); //the Kendo widget
+    ```JavaScript
+    var timelineObject  = $find("<%=RadTimeline1.ClientID %>"); //the standard script control object
+    var kendoTimeline = timelineObject.get_kendoWidget(); //the Kendo widget
+    ```
 
 * Get the Kendo Widget in its usual way. Make sure to use the `$telerik._kendo.jQuery` reference that has the Kendo widget data:
 
-    **JavaScript**
-    
-        var kendoTimeline = $telerik._kendo.jQuery("#<%=RadTimeline1.ClientID %>").data("kendoTimeline"); //the jQuery selector must get the RadTimeline1 wrapper span element
+    ```JavaScript
+    var kendoTimeline = $telerik._kendo.jQuery("#<%=RadTimeline1.ClientID %>").data("kendoTimeline"); //the jQuery selector must get the RadTimeline1 wrapper span element
+    ```
 
 >important As of the 2026 Q1 release, Kendo jQuery widget plugins and data are registered on `$telerik._kendo.jQuery` — a different jQuery instance from `$telerik.$`. If you use `$telerik.$` with `.data("kendoXxx")`, it will return `undefined`. Always use `$telerik._kendo.jQuery` when accessing the underlying Kendo widget via the `.data()` method. The recommended approach, however, is to use the `get_kendoWidget()` method shown above.
 

--- a/controls/togglebutton/appearance-and-styling/create-a-custom-skin.md
+++ b/controls/togglebutton/appearance-and-styling/create-a-custom-skin.md
@@ -40,22 +40,22 @@ The second file represents the actual skin of the control, and its name consists
 
 1. Add a new server declaration of **RadToggleButton** on your page and set **Skin="MyCustomSkin"** and **EnableEmbeddedSkins="false"**:
 
-	**ASP.NET**
-
-		<telerik:RadToggleButton runat="server" ID="RadToggleButton1" Skin="MyCustomSkin" EnableEmbeddedSkins="false">
-			<ToggleStates>
-				<telerik:ButtonToggleState Text="First state">
-				</telerik:ButtonToggleState>
-				<telerik:ButtonToggleState Text="Second State">
-				</telerik:ButtonToggleState>
-			</ToggleStates>
-		</telerik:RadToggleButton>
+	```ASP.NET
+	<telerik:RadToggleButton runat="server" ID="RadToggleButton1" Skin="MyCustomSkin" EnableEmbeddedSkins="false">
+		<ToggleStates>
+			<telerik:ButtonToggleState Text="First state">
+			</telerik:ButtonToggleState>
+			<telerik:ButtonToggleState Text="Second State">
+			</telerik:ButtonToggleState>
+		</ToggleStates>
+	</telerik:RadToggleButton>
+	```
 
 1. Register **Button.MyCustomSkin.css** in the head section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 
-	**ASP.NET**
-
-		<link href="Skins/MyCustomSkinLite/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+	```ASP.NET
+	<link href="Skins/MyCustomSkinLite/Button.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+	```
 
 1. Make sure the path to the files is correct; otherwise the skin will not apply.
 

--- a/controls/togglebutton/functionality/Icons/custom-icons.md
+++ b/controls/togglebutton/functionality/Icons/custom-icons.md
@@ -70,29 +70,28 @@ You can use custom font icons in **RadToggleButton** as well. To do that, follow
 
 1. Load the stylesheet with the desired font icons on the page.
 
-	**CSS**
-
-		<link rel="stylesheet" href="myCustomFontStyleSheet.css" />
+	```CSS
+	<link rel="stylesheet" href="myCustomFontStyleSheet.css" />
+	```
 
 1. Override the font-family of the button's icon element with the target one (see **Example 3**).
 
-	**CSS**
-
-		button.RadButton .rbIcon:before {
-			font-family: myCustomFont;
-		}
+	```CSS
+	button.RadButton .rbIcon:before {
+		font-family: myCustomFont;
+	}
+	```
 
 1. Set the custom font icon class to the **Icon.CssClass** property of the desired toggle state.
 
-	**ASP.NET**
-
-		<telerik:RadToggleButton ID="RadToggleButton1" runat="server" Text="Button With Custom Font Icon">
-			<ToggleStates>
-				<telerik:ButtonToggleState>
-					<Icon CssClass="myCustomFontIconClass1" />
-				</telerik:ButtonToggleState>
-				<telerik:ButtonToggleState>
-					<Icon CssClass="myCustomFontIconClass2" />
+	```ASP.NET
+	<telerik:RadToggleButton ID="RadToggleButton1" runat="server" Text="Button With Custom Font Icon">
+		<ToggleStates>
+			<telerik:ButtonToggleState>
+				<Icon CssClass="myCustomFontIconClass1" />
+			</telerik:ButtonToggleState>
+			<telerik:ButtonToggleState>
+				<Icon CssClass="myCustomFontIconClass2" />
 				</telerik:ButtonToggleState>
 			</ToggleStates>
 		</telerik:RadToggleButton>

--- a/controls/togglebutton/getting-started.md
+++ b/controls/togglebutton/getting-started.md
@@ -14,73 +14,73 @@ The following tutorial demonstrates how to set up a page with a **RadToggleButto
 
 1. In the default page of a new ASP.NET AJAX-enabled Web Application add a **RadToggleButton** control:
 
-	**ASP.NET**	
-	
-		<telerik:RadToggleButton ID="RadToggleButton1" runat="server">
-		</telerik:RadToggleButton>	
+	```ASP.NET
+	<telerik:RadToggleButton ID="RadToggleButton1" runat="server">
+	</telerik:RadToggleButton>	
+	```
 
 1. Add two states the user can switch between and set their `Text`, `Value` and `CommandArgument` properties so you can distinguish them on the server:
 
-	**ASP.NET**
-
-		<telerik:RadToggleButton runat="server" ID="RadToggleButton1">
-			<ToggleStates>
-				<telerik:ButtonToggleState Text="First state" Value="0" CommandArgument="arg1">
-				</telerik:ButtonToggleState>
-				<telerik:ButtonToggleState Text="Second State" Value="1" CommandArgument="arg2">
-				</telerik:ButtonToggleState>
-			</ToggleStates>
-		</telerik:RadToggleButton>
+	```ASP.NET
+	<telerik:RadToggleButton runat="server" ID="RadToggleButton1">
+		<ToggleStates>
+			<telerik:ButtonToggleState Text="First state" Value="0" CommandArgument="arg1">
+			</telerik:ButtonToggleState>
+			<telerik:ButtonToggleState Text="Second State" Value="1" CommandArgument="arg2">
+			</telerik:ButtonToggleState>
+		</ToggleStates>
+	</telerik:RadToggleButton>
+	```
 
 1. To hook to the **OnToggleStateChanged** server-side event of **RadToggleButton** add an attribute to the main control tag and add the method signature:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadToggleButton runat="server" ID="RadToggleButton1" OnToggleStateChanged="RadToggleButton1_ToggleStateChanged">
+		<ToggleStates>
+			<telerik:ButtonToggleState Text="First state" Value="0" CommandArgument="arg1">
+			</telerik:ButtonToggleState>
+			<telerik:ButtonToggleState Text="Second State" Value="1" CommandArgument="arg2">
+			</telerik:ButtonToggleState>
+		</ToggleStates>
+	</telerik:RadToggleButton>
+	```
 
-		<telerik:RadToggleButton runat="server" ID="RadToggleButton1" OnToggleStateChanged="RadToggleButton1_ToggleStateChanged">
-			<ToggleStates>
-				<telerik:ButtonToggleState Text="First state" Value="0" CommandArgument="arg1">
-				</telerik:ButtonToggleState>
-				<telerik:ButtonToggleState Text="Second State" Value="1" CommandArgument="arg2">
-				</telerik:ButtonToggleState>
-			</ToggleStates>
-		</telerik:RadToggleButton>
+	```C#
+	protected void RadToggleButton1_ToggleStateChanged(object sender, ToggleButtonStateChangedEventArgs e)
+	{
+	
+	}
+	```
 
-	**C#**
-	
-		protected void RadToggleButton1_ToggleStateChanged(object sender, ToggleButtonStateChangedEventArgs e)
-		{
-	
-		}
-
-	**VB**
-	
-		Protected Sub RadToggleButton1_ToggleStateChanged(ByVal sender As Object, ByVal e As ToggleButtonStateChangedEventArgs)
-		End Sub
+	```VB
+	Protected Sub RadToggleButton1_ToggleStateChanged(ByVal sender As Object, ByVal e As ToggleButtonStateChangedEventArgs)
+	End Sub
+	```
 
 1. Add a Label control to write the information to:
 
-	**ASP.NET**
-
-		<asp:Label ID="Label1" Text="" runat="server" />
+	```ASP.NET
+	<asp:Label ID="Label1" Text="" runat="server" />
+	```
 
 1. Use the **OnToggleStateChanged** event handler to write information about the current button state:
 
-	**C#**
-	
-		protected void RadToggleButton1_ToggleStateChanged(object sender, ToggleButtonStateChangedEventArgs e)
-		{
-			string data = string.Format("current text: {0}, current value {1}, current command argument: {2}",
-										 e.SelectedToggleState.Text, e.SelectedToggleState.Value, e.SelectedToggleState.CommandArgument);
-			Label1.Text = data;
-		}
+	```C#
+	protected void RadToggleButton1_ToggleStateChanged(object sender, ToggleButtonStateChangedEventArgs e)
+	{
+		string data = string.Format("current text: {0}, current value {1}, current command argument: {2}",
+									 e.SelectedToggleState.Text, e.SelectedToggleState.Value, e.SelectedToggleState.CommandArgument);
+		Label1.Text = data;
+	}
+	```
 
-	**VB**
-	
-		Protected Sub RadToggleButton1_ToggleStateChanged(sender As Object, e As ToggleButtonStateChangedEventArgs)
-			Dim data As String = String.Format("current text: {0}, current value {1}, current command argument: {2}", _
-												 e.SelectedToggleState.Text, e.SelectedToggleState.Value, e.SelectedToggleState.CommandArgument)
-			Label1.Text = data
-		End Sub
+	```VB
+	Protected Sub RadToggleButton1_ToggleStateChanged(sender As Object, e As ToggleButtonStateChangedEventArgs)
+		Dim data As String = String.Format("current text: {0}, current value {1}, current command argument: {2}", _
+									 e.SelectedToggleState.Text, e.SelectedToggleState.Value, e.SelectedToggleState.CommandArgument)
+		Label1.Text = data
+	End Sub
+	```
 
 ## See Also
 

--- a/controls/togglebutton/mobile-support/render-modes.md
+++ b/controls/togglebutton/mobile-support/render-modes.md
@@ -21,23 +21,23 @@ There are two ways to configure the rendering mode of the **RadToggleButton**:
 
 * The **RenderMode property** in the markup or in the code-behind can be used for a particular instance:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadToggleButton ID="RadToggleButton1" runat="server" RenderMode="Lightweight">
+		<ToggleStates>
+			<telerik:ButtonToggleState Text="State 1"/>
+			<telerik:ButtonToggleState Text="State 2" /> 
+		</ToggleStates>
+	</telerik:RadToggleButton>
+	```
 
-		<telerik:RadToggleButton ID="RadToggleButton1" runat="server" RenderMode="Lightweight">
-			<ToggleStates>
-				<telerik:ButtonToggleState Text="State 1"/>
-				<telerik:ButtonToggleState Text="State 2" /> 
-			</ToggleStates>
-		</telerik:RadToggleButton>
 
+	```C#
+	RadToggleButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	```
 
-	**C#**
-
-		RadToggleButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-
-	**VB**
-
-		RadToggleButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```VB
+	RadToggleButton1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```
 
 
 * A **global setting in the web.config** file that will affect the entire application, unless a concrete value is specified for a given control instance:

--- a/controls/tooltip/mobile-support/render-modes.md
+++ b/controls/tooltip/mobile-support/render-modes.md
@@ -28,31 +28,31 @@ There are two ways to configure the rendering mode of the controls:
 
 * The **RenderMode property** in the markup or in the code-behind that can be used for a particular instance:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadToolTip ID="RadToolTip1" runat="server" RenderMode="Lightweight">
+	</telerik:RadToolTip>
+	<telerik:RadToolTipManager ID="RadToolTipManager1" runat="server" RenderMode="Lightweight">
+	</telerik:RadToolTipManager>
+	```
 
-		<telerik:RadToolTip ID="RadToolTip1" runat="server" RenderMode="Lightweight">
-		</telerik:RadToolTip>
-		<telerik:RadToolTipManager ID="RadToolTipManager1" runat="server" RenderMode="Lightweight">
-		</telerik:RadToolTipManager>
 
+	```C#
+	RadToolTip1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	RadToolTipManager1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
+	```
 
-	**C#**
-
-		RadToolTip1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-		RadToolTipManager1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight;
-
-	**VB**
-
-		RadToolTip1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
-		RadToolTipManager1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```VB
+	RadToolTip1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	RadToolTipManager1.RenderMode = Telerik.Web.UI.RenderMode.Lightweight
+	```
 
 
 
 * A **global setting in the web.config** file that will affect the entire application, unless a concrete value is specified for a given control instance:
 
-	**XML**
-		
-		<appSettings>
-			<add key="Telerik.Web.UI.ToolTip.RenderMode" value="Lightweight" />
-		</appSettings>
+	```XML
+	<appSettings>
+		<add key="Telerik.Web.UI.ToolTip.RenderMode" value="Lightweight" />
+	</appSettings>
+	```
 

--- a/controls/tooltip/troubleshooting/common-issues.md
+++ b/controls/tooltip/troubleshooting/common-issues.md
@@ -139,21 +139,21 @@ There are several ways to handle such an error because it stems from the `PageRe
 
 * handle the `endRequestEvent` and prevent the error alert. The following snippet should prevent it for all server errors trapped by MS AJAX:
 
-	**JavaScript**
-
-		function endRequestHandler(sender, args) {
-		    args.set_errorHandled(true);
-		}
-		var prm = Sys.WebForms.PageRequestManager.getInstance();
-		prm.add_endRequest(endRequestHandler);
+	```JavaScript
+	function endRequestHandler(sender, args) {
+	    args.set_errorHandled(true);
+	}
+	var prm = Sys.WebForms.PageRequestManager.getInstance();
+	prm.add_endRequest(endRequestHandler);
+	```
 
 * If possible, use a WebService for the [tooltip manager's load-on-demand]({%slug tooltip/radtooltipmanager/load-content-on-demand%}#loading-content-via-a-webservice), to avoid subsequent AJAX requests.
 
 * As a last resort, add the following function override at the end of your page. It will prevent the tooltip manager error handling, alerts and events.
 
-	**JavaScript**
-
-		Telerik.Web.UI.RadToolTipManager.prototype._onError = function (message) { }
+	```JavaScript
+	Telerik.Web.UI.RadToolTipManager.prototype._onError = function (message) { }
+	```
 
 
 ## AJAX-enable RadToolTip Content
@@ -165,15 +165,15 @@ There are a few ways to handle this situation:
 
 * AJAX-enable the tooltip contents themselves, e.g.:
 
-	**ASP.NET**
-
-		<telerik:RadToolTip ID="RadToolTip1" runat="server" RenderInPageRoot="false">
-			<asp:UpdatePanel ID="Updatepanel1" runat="server" UpdateMode="Conditional">
-				<ContentTemplate>
-					<asp:Button ID="Button1" Text="I will perform an AJAX request now" runat="server" />
-				</ContentTemplate>
-			</asp:UpdatePanel>
-		</telerik:RadToolTip>
+	```ASP.NET
+	<telerik:RadToolTip ID="RadToolTip1" runat="server" RenderInPageRoot="false">
+		<asp:UpdatePanel ID="Updatepanel1" runat="server" UpdateMode="Conditional">
+			<ContentTemplate>
+				<asp:Button ID="Button1" Text="I will perform an AJAX request now" runat="server" />
+			</ContentTemplate>
+		</asp:UpdatePanel>
+	</telerik:RadToolTip>
+	```
 
 * Set the [`RenderInPageRoot`](https://demos.telerik.com/aspnet-ajax/tooltip/examples/tooltipasformchild/defaultcs.aspx) property of the RadToolTip instance to `false`. Note that if its parent has absolute positioning, this may result in incorrect RadToolTip positions because it will not inherit the CSS rules of its parent. Also, note that the AJAX request will dispose the tooltip as well as the button and the parent element, so the tooltip will hide.
 

--- a/controls/treelist/functionality/exporting/integration-with-telerik-document-processing-library.md
+++ b/controls/treelist/functionality/exporting/integration-with-telerik-document-processing-library.md
@@ -32,11 +32,12 @@ The following steps walk you through the entire process of creating an Excel doc
 
 1. Create an instance of the Workbook class and add a new Worksheet object to the Worksheets collection.
 
-	**C#**
+	```C#
 	
 		Workbook workbook = new Workbook();
 		Worksheet worksheet = workbook.Worksheets.Add();
-	
+	```
+
 	**VB.NET**
 	
 		Dim workbook As New Workbook()
@@ -46,7 +47,7 @@ The following steps walk you through the entire process of creating an Excel doc
 
 
 
-	**C#**
+	```C#
 	
 		static TreeListItemType[] supportedItemTypes = new TreeListItemType[] 
 		{ 
@@ -54,13 +55,14 @@ The following steps walk you through the entire process of creating an Excel doc
 			TreeListItemType.AlternatingItem, 
 			TreeListItemType.Item 
 		};
-	
+	```
+
 	**VB.NET**
 	
 		Shared supportedItemTypes As TreeListItemType() = New TreeListItemType() {TreeListItemType.HeaderItem, TreeListItemType.AlternatingItem, TreeListItemType.Item}
 
 
-	**C#**
+	```C#
 	
 		TreeListItem item;
 
@@ -111,6 +113,7 @@ The following steps walk you through the entire process of creating an Excel doc
 				}
 			}
 		}
+	```
 
 	**VB.NET**
 	
@@ -155,9 +158,8 @@ The following steps walk you through the entire process of creating an Excel doc
 
 
 
-	**C#**
-	
-		Workbook workbook = structure as Workbook;
+	```C#
+	Workbook workbook = structure as Workbook;
 		byte[] output;
 
 		using (MemoryStream ms = new MemoryStream())
@@ -174,7 +176,8 @@ The following steps walk you through the entire process of creating an Excel doc
 		Response.AddHeader("content-disposition", "attachment; filename=" + fileName);
 		Response.BinaryWrite(output);
 		Response.Flush();
-		Response.Close();
+	Response.Close();
+	```
 
 	**VB.NET**
 	
@@ -443,11 +446,11 @@ The following steps walk you through the entire process of creating an Word docu
 
 
 
-	**C#**
-	
-		RadFlowDocument flowDoc = new RadFlowDocument();
-		Section section = flowDoc.Sections.AddSection();
-		Table mainTable = section.Blocks.AddTable();
+	```C#
+	RadFlowDocument flowDoc = new RadFlowDocument();
+	Section section = flowDoc.Sections.AddSection();
+	Table mainTable = section.Blocks.AddTable();
+	```
 
 	**VB.NET**
 	
@@ -459,23 +462,22 @@ The following steps walk you through the entire process of creating an Word docu
 
 
 
-	**C#**
-	
-		static TreeListItemType[] supportedItemTypes = new TreeListItemType[] 
-		{ 
-			TreeListItemType.HeaderItem, 
-			TreeListItemType.AlternatingItem, 
-			TreeListItemType.Item 
-		};
-	
+	```C#
+	static TreeListItemType[] supportedItemTypes = new TreeListItemType[] 
+	{ 
+		TreeListItemType.HeaderItem, 
+		TreeListItemType.AlternatingItem, 
+		TreeListItemType.Item 
+	};
+	```
+
 	**VB.NET**
 	
 		Shared supportedItemTypes As TreeListItemType() = New TreeListItemType() {TreeListItemType.HeaderItem, TreeListItemType.AlternatingItem, TreeListItemType.Item}
 	
 
-	**C#**
-	
-		TreeListItem item;
+	```C#
+	TreeListItem item;
 		TableRow row;
 
 		var treeListItems = RadTreeList1.GetItems(supportedItemTypes);
@@ -516,7 +518,8 @@ The following steps walk you through the entire process of creating an Word docu
 
 				SetDocxCellText(td, GetCellText(cellText));
 			}
-		}
+	}
+	```
 
 	**VB.NET**
 	
@@ -560,9 +563,8 @@ The following steps walk you through the entire process of creating an Word docu
 
 
 
-	**C#**
-	
-		RadFlowDocument flowDoc = structure as RadFlowDocument;
+	```C#
+	RadFlowDocument flowDoc = structure as RadFlowDocument;
 
 		byte[] output;
 
@@ -579,7 +581,8 @@ The following steps walk you through the entire process of creating an Word docu
 		Response.AddHeader("content-disposition", "attachment; filename=" + fileName);
 		Response.BinaryWrite(output);
 		Response.Flush();
-		Response.Close();
+	Response.Close();
+	```
 
 	**VB.NET**
 	

--- a/controls/window/alert,-confirm,-prompt-dialogs/how-to-change-the-dialog-templates.md
+++ b/controls/window/alert,-confirm,-prompt-dialogs/how-to-change-the-dialog-templates.md
@@ -316,9 +316,8 @@ This topic contains the following sections.
 
 1. Add your new template to the **RadWindowManager**. For example:
 
-	**ASP.NET**
-	    
-		<telerik:RadWindowManager ID="RadWindowManager1" runat="server">
+	```ASP.NET
+	<telerik:RadWindowManager ID="RadWindowManager1" runat="server">
 			<AlertTemplate>
 				<div class="rwDialogPopup radalert">
 					<div class="rwDialogText">
@@ -331,7 +330,8 @@ This topic contains the following sections.
 					</div>
 				</div>
 			</AlertTemplate>
-		</telerik:RadWindowManager>
+	</telerik:RadWindowManager>
+	```
 
 ## Changing the Templates through the Code-Behind
 
@@ -343,9 +343,8 @@ The second way to change the template that the **RadWindowManager** in your appl
 
 1. In the AlertTemplate.ascx file, design your new template. For example
 
-	**ASP.NET**
-		
-		<%@  control language="C#" classname="AlertTemplate" %>
+	```ASP.NET
+	<%@  control language="C#" classname="AlertTemplate" %>
 		<div class="rwDialogPopup radalert">
 			<div class="rwDialogText">
 				{1}
@@ -355,53 +354,54 @@ The second way to change the template that the **RadWindowManager** in your appl
 					<span class="rwOuterSpan"><span class="rwInnerSpan">##LOC[OK]##</span> </span>
 				</a>
 			</div>
-		</div>
+	</div>
+	```
 
 1. Each of the Template properties is an ITemplate type. Implement an ITemplate class to load the new Web User Control that you defined. This class gains a reference to the web page in its constructor. The implementation of the one ITemplate method, **InstantiateIn**(), then loads the Web User Control onto that page and adds it to the supplied owner:
 
-	**C#**
-	
-		class AlertTemplate : ITemplate
+	```C#
+	class AlertTemplate : ITemplate
+	{
+		private Page _page;
+		public AlertTemplate(Page page)
 		{
-			private Page _page;
-			public AlertTemplate(Page page)
-			{
-				this._page = page;
-			}
-			void ITemplate.InstantiateIn(Control owner)
-			{
-				Control ctrl = _page.LoadControl("AlertTemplate.ascx");
-				owner.Controls.Add(ctrl);
-			}
-		} 
+			this._page = page;
+		}
+		void ITemplate.InstantiateIn(Control owner)
+		{
+			Control ctrl = _page.LoadControl("AlertTemplate.ascx");
+			owner.Controls.Add(ctrl);
+		}
+	} 
+	```
 	
-	**VB**	
-	
-	    Class AlertTemplate
-	        Implements ITemplate
-	        Private _page As Page
-	        Public Sub New(ByVal page As Page)
-	            Me._page = page
-	        End Sub
-	        Sub InstantiateIn(ByVal owner As Control) Implements ITemplate.InstantiateIn
-	            Dim ctrl As Control = _page.LoadControl("AlertTemplate.ascx")
-	            owner.Controls.Add(ctrl)
-	        End Sub
-	    End Class
+	```VB
+	Class AlertTemplate
+	    Implements ITemplate
+	    Private _page As Page
+	    Public Sub New(ByVal page As Page)
+	        Me._page = page
+	    End Sub
+	    Sub InstantiateIn(ByVal owner As Control) Implements ITemplate.InstantiateIn
+	        Dim ctrl As Control = _page.LoadControl("AlertTemplate.ascx")
+	        owner.Controls.Add(ctrl)
+	    End Sub
+	End Class
+	```
 
 1. In the **Page_Load** event handler of the page that contains your **RadWindowManager**, create an instance of your new ITemplate class and assign the instance as the value of the appropriate template property:
 
-	**C#**
+	```C#
+	protected void Page_Load(object sender, EventArgs e)
+	{
+		this.RadWindowManager1.AlertTemplate = new AlertTemplate(this.Page);
+	} 
+	```
 	
-		protected void Page_Load(object sender, EventArgs e)
-		{
-			this.RadWindowManager1.AlertTemplate = new AlertTemplate(this.Page);
-		} 
-	
-	**VB**
-	
-	    Protected Sub Page_Load(ByVal sender As Object, ByVal e As EventArgs)
-	        Me.RadWindowManager1.AlertTemplate = New AlertTemplate(Me.Page)
-	    End Sub
+	```VB
+	Protected Sub Page_Load(ByVal sender As Object, ByVal e As EventArgs)
+	    Me.RadWindowManager1.AlertTemplate = New AlertTemplate(Me.Page)
+	End Sub
+	```
 
 

--- a/controls/window/appearance-and-styling/creating-custom-lightweight-skin.md
+++ b/controls/window/appearance-and-styling/creating-custom-lightweight-skin.md
@@ -43,15 +43,15 @@ Since Q2 2013 RadWindow has a LightWeight render mode, which uses semantically s
 
 9. Add a new server declaration of **RadWindow** on your page, and set **Skin="MyCustomSkin"** and **EnableEmbeddedSkins="false"**: 
 
-	**ASP.NET**
-	
-		<telerik:RadWindow ID="RadWindow1" runat="server"  EnableEmbeddedSkins="false" Skin="MyCustomSkin" />
+    ```ASP.NET
+    <telerik:RadWindow ID="RadWindow1" runat="server"  EnableEmbeddedSkins="false" Skin="MyCustomSkin" />
+    ```
 		
 10. Register **Window.MyCustomSkin.css** in the head section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 
-	**ASP.NET**
-	
-		<link href="Skins/MyCustomSkin/Window.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+    ```ASP.NET
+    <link href="Skins/MyCustomSkin/Window.MyCustomSkin.css" rel="stylesheet" type="text/css" />
+    ```
 		
 1. Make sure the path to the files is correct; otherwise the skin will not apply;
 

--- a/controls/window/appearance-and-styling/radwindow-css-classes-and-their-use.md
+++ b/controls/window/appearance-and-styling/radwindow-css-classes-and-their-use.md
@@ -42,19 +42,19 @@ In order to explain better the CSS classes of RadWindow, we will use both Window
 
 1. Put a new server declaration of RadWindow on your page, and set **Skin="MyCustomSkin", EnableEmbeddedSkins="false"** and **EnableEmbeddedBasestylesheet="false"**:
 
-	**ASP.NET**
-	
-		<telerik:RadWindow RenderMode="Lightweight" ID="RadWindow1" runat="server" NavigateUrl="http://www.google.com"
-			Title="Google" Skin="MyCustomSkin" EnableEmbeddedSkins="false" EnableEmbeddedBaseStylesheet="false"
-			VisibleOnPageLoad="true">
-		</telerik:RadWindow>
+	```ASP.NET
+	<telerik:RadWindow RenderMode="Lightweight" ID="RadWindow1" runat="server" NavigateUrl="http://www.google.com"
+		Title="Google" Skin="MyCustomSkin" EnableEmbeddedSkins="false" EnableEmbeddedBaseStylesheet="false"
+		VisibleOnPageLoad="true">
+	</telerik:RadWindow>
+	```
 
 1. Register **Window.css** and **Window.MyCustomSkin.css** in the <head>...</head> section of your web page. In order to have the CSS applied correctly, the base stylesheet should come first in the DOM:
 
-	**ASP.NET**
-	
-		<link rel="stylesheet" type="text/css" href="Skins/Window.css"></link>
-		<link rel="stylesheet" type="text/css" href="Skins/MyCustomSkin/Window.MyCustomSkin.css"></link>
+	```ASP.NET
+	<link rel="stylesheet" type="text/css" href="Skins/Window.css"></link>
+	<link rel="stylesheet" type="text/css" href="Skins/MyCustomSkin/Window.MyCustomSkin.css"></link>
+	```
 
 1. Make sure the path to the files is correct, otherwise the skin will not apply.
 
@@ -229,68 +229,68 @@ Each skin of RadWindow consists of three [image sprites](http://www.alistapart.c
 
 1. Classes that use WindowHorizontalSprites.gif. Their use has already been explained in **The Base Stylesheet - Window.css**
 
-	**CSS**
-	        
-		.RadWindow_MyCustomSkin .rwTopLeft, 
-		.RadWindow_MyCustomSkin .rwTopRight, 
-		.RadWindow_MyCustomSkin .rwTitlebar, 
-		.RadWindow_MyCustomSkin .rwFooterLeft, 
-		.RadWindow_MyCustomSkin .rwFooterRight, 
-		.RadWindow_MyCustomSkin .rwFooterCenter, 
-		.RadWindow_MyCustomSkin .rwTopResize, 
-		.RadWindow_MyCustomSkin .rwStatusbar div, 
-		.RadWindow_MyCustomSkin .rwStatusbar, 
-		.RadWindow_MyCustomSkin .rwPopupButton, 
-		.RadWindow_MyCustomSkin .rwPopupButton span, 
-		.RadWindow_MyCustomSkin.rwMinimizedWindow .rwCorner
-		{
-			background-image: url('Window/WindowHorizontalSprites.gif');
-		}
+	```CSS
+	.RadWindow_MyCustomSkin .rwTopLeft, 
+	.RadWindow_MyCustomSkin .rwTopRight, 
+	.RadWindow_MyCustomSkin .rwTitlebar, 
+	.RadWindow_MyCustomSkin .rwFooterLeft, 
+	.RadWindow_MyCustomSkin .rwFooterRight, 
+	.RadWindow_MyCustomSkin .rwFooterCenter, 
+	.RadWindow_MyCustomSkin .rwTopResize, 
+	.RadWindow_MyCustomSkin .rwStatusbar div, 
+	.RadWindow_MyCustomSkin .rwStatusbar, 
+	.RadWindow_MyCustomSkin .rwPopupButton, 
+	.RadWindow_MyCustomSkin .rwPopupButton span, 
+	.RadWindow_MyCustomSkin.rwMinimizedWindow .rwCorner
+	{
+		background-image: url('Window/WindowHorizontalSprites.gif');
+	}
+	```
 
 1. Classes that use WindowVerticalSprites.gif. Their use has already been explained in **The Base Stylesheet - Window.css**
 
-	**CSS**
-	        
-		.RadWindow_MyCustomSkin .rwBodyLeft, .RadWindow_MyCustomSkin .rwBodyRight, .RadWindow_MyCustomSkin .rwStatusbarRow .rwCorner
-		{
-			background-image: url('Window/WindowVerticalSprites.gif');
-		}
+	```CSS
+	.RadWindow_MyCustomSkin .rwBodyLeft, .RadWindow_MyCustomSkin .rwBodyRight, .RadWindow_MyCustomSkin .rwStatusbarRow .rwCorner
+	{
+		background-image: url('Window/WindowVerticalSprites.gif');
+	}
+	```
 
 1. RadWindow Statusbar Input
 
-	**CSS**
-	        
-		.RadWindow_MyCustomSkin .rwStatusbar input
-		{
-			background-color: #f7f3e9;
-		}
+	```CSS
+	.RadWindow_MyCustomSkin .rwStatusbar input
+	{
+		background-color: #f7f3e9;
+	}
+	```
 
 1. Classes that use CommandButtonSprites.gif. Their use has already been explained in **The Base Stylesheet - Window.css**
 
-	**CSS**	        
-
-		.RadWindow_MyCustomSkin .rwControlButtons a
-		{
-			background-image: url('Window/CommandButtonSprites.gif');
-		}
+	```CSS
+	.RadWindow_MyCustomSkin .rwControlButtons a
+	{
+		background-image: url('Window/CommandButtonSprites.gif');
+	}
+	```
 
 1. RadWindow Icon
 
-	**CSS**
-	        
-		.RadWindow_MyCustomSkin a.rwIcon
-		{
-			background-image: url('Window/WindowHorizontalSprites.gif');
-		}
+	```CSS
+	.RadWindow_MyCustomSkin a.rwIcon
+	{
+		background-image: url('Window/WindowHorizontalSprites.gif');
+	}
+	```
 
 1. RadWindow Titlebar Text
 
-	**CSS**
-	        
-		div.RadWindow_MyCustomSkin .rwTitlebarControls em
-		{
-			color: black;
-		}
+	```CSS
+	div.RadWindow_MyCustomSkin .rwTitlebarControls em
+	{
+		color: black;
+	}
+	```
 	        
 Understanding the Image Sprites
 

--- a/controls/window/client-side-programming/events/overview.md
+++ b/controls/window/client-side-programming/events/overview.md
@@ -43,15 +43,14 @@ The following example illustrates how client-side events work.
 
 1. Go to the source view, and add the following code to the markup of your page:
 
-	**JavaScript**
-	
-		/**********************************************************
-		Window Events
-		**********************************************************/
-		function OnClientCommand(sender, eventArgs)
-		{
-			logEvent("<strong>OnClientCommand</strong>: Command is " + eventArgs.get_commandName());
-		}
+	```JavaScript
+	/**********************************************************
+	Window Events
+	**********************************************************/
+	function OnClientCommand(sender, eventArgs)
+	{
+		logEvent("<strong>OnClientCommand</strong>: Command is " + eventArgs.get_commandName());
+	}
 
 
 		function OnClientResizeEnd(sender, eventArgs)
@@ -122,12 +121,13 @@ The following example illustrates how client-side events work.
 		/**********************************************************
 		Helper
 		**********************************************************/
-		function LogEvent(eventString)
-		{
-			var d = new Date();
-			var dateStr = d.getHours() + ":" + d.getMinutes() + ":" + d.getSeconds() + "." + d.getMilliseconds();
-			document.getElementById("eventConsole").innerHTML = "[" + dateStr + "] " + eventString + "<br/>" + document.getElementById("eventConsole").innerHTML;
-		}
+	function LogEvent(eventString)
+	{
+		var d = new Date();
+		var dateStr = d.getHours() + ":" + d.getMinutes() + ":" + d.getSeconds() + "." + d.getMilliseconds();
+		document.getElementById("eventConsole").innerHTML = "[" + dateStr + "] " + eventString + "<br/>" + document.getElementById("eventConsole").innerHTML;
+	}
+	```
 
 	This markup first defines some JavaScript functions: a helper function called LogEvent which writes information about the event to a `<div>` element on the page (in the sample above its ID is "eventConsole") and a set of 12 event handlers (the OnClientResize would flood the console, this is why we leave it out), each of which takes two arguments and calls LogEvent to display information about the event. After the `<script>` section, the markup adds two links to the page for opening the windows, and a `<div>` section to display the information written by the `LogEvent` function.
 

--- a/controls/window/getting-started/overview.md
+++ b/controls/window/getting-started/overview.md
@@ -79,17 +79,17 @@ Before continuing with the multiple window example, you need to create a dialog 
 
 1. Move to the **Source** view and change the title for this form to **"My Dialog"**. The markup should look similar to this:
 
-	**ASP.NET**	     
-	
-		<head runat="server">
-		  <title>My Dialog</title>
-		</head>
-		<body>
-		  <form id="form1" runat="server">
-		  <div>
-			My dialog content here...</div>
-		  </form>
-		</body>
+	```ASP.NET
+	<head runat="server">
+	  <title>My Dialog</title>
+	</head>
+	<body>
+	  <form id="form1" runat="server">
+	  <div>
+		My dialog content here...</div>
+	  </form>
+	</body>
+	```
 
 
 ## Launching Windows from Another Control

--- a/controls/window/how-to/executing-script-on-a-reload.md
+++ b/controls/window/how-to/executing-script-on-a-reload.md
@@ -14,59 +14,59 @@ There are times when you want to perform a postback from a **RadWindow** object,
 
 1. To execute the client-side script on a reload, first add the JavaScript to the dialog page:
 
-	**JavaScript**
-
-		//GetRadWindow obtains a reference to the hosting RadWindow"
-		function GetRadWindow()
-		{
-			var oWindow = null;
-			if (window.radWindow)
-				oWindow = window.radWindow;
-			else if (window.frameElement.radWindow)
-				oWindow = window.frameElement.radWindow;
-			return oWindow;
-		}
-		function CloseOnReload()
-		{
-			GetRadWindow().close();
-		}
-		function RefreshParentPage()
-		{
-			GetRadWindow().BrowserWindow.location.href = GetRadWindow().BrowserWindow.location.href;
-		}
+	```JavaScript
+	//GetRadWindow obtains a reference to the hosting RadWindow"
+	function GetRadWindow()
+	{
+		var oWindow = null;
+		if (window.radWindow)
+			oWindow = window.radWindow;
+		else if (window.frameElement.radWindow)
+			oWindow = window.frameElement.radWindow;
+		return oWindow;
+	}
+	function CloseOnReload()
+	{
+		GetRadWindow().close();
+	}
+	function RefreshParentPage()
+	{
+		GetRadWindow().BrowserWindow.location.href = GetRadWindow().BrowserWindow.location.href;
+	}
+	```
 
 1. Add controls to trigger the postback:
 
-	**ASP.NET**
-	    
-		<asp:Button ID="Button1" runat="server" OnClick="Button1_Click" Text="Do something and close" />
-	    <asp:Button ID="Button2" runat="server" OnClick="Button2_Click" Text="Change the main page" />
+	```ASP.NET
+	<asp:Button ID="Button1" runat="server" OnClick="Button1_Click" Text="Do something and close" />
+	<asp:Button ID="Button2" runat="server" OnClick="Button2_Click" Text="Change the main page" />
+	```
 
 1. In the handlers that perform the server-side actions, you can use page's RegisterStartupScript collection to add a script that should be executed when the page is reloaded:
 
 
 
-	**C#**
-	    
-		private void Button1_Click(object sender, System.EventArgs e)
-	    {
-	        // perform the server-side actions here and then...
-	        ClientScript.RegisterStartupScript(Page.GetType(), "closeWindow", "<script type='text/javascript'>CloseOnReload()</script>");
-	    }
-	    private void Button2_Click(object sender, System.EventArgs e)
-	    {
-	        // perform the server-side actions here and then...
-	        ClientScript.RegisterStartupScript(Page.GetType(), "closeWindow", "<script type='text/javascript'>RefreshParentPage()</script>");
-	    }
+	```C#
+	private void Button1_Click(object sender, System.EventArgs e)
+	{
+	    // perform the server-side actions here and then...
+	    ClientScript.RegisterStartupScript(Page.GetType(), "closeWindow", "<script type='text/javascript'>CloseOnReload()</script>");
+	}
+	private void Button2_Click(object sender, System.EventArgs e)
+	{
+	    // perform the server-side actions here and then...
+	    ClientScript.RegisterStartupScript(Page.GetType(), "closeWindow", "<script type='text/javascript'>RefreshParentPage()</script>");
+	}
+	```
 		
-	**VB**
-	
-	    Private Sub Button1_Click(ByVal sender As Object, ByVal e As System.EventArgs)
-	        ClientScript.RegisterStartupScript(Page.GetType(), "closeWindow", "<script type='text/javascript'>CloseOnReload()</script>")
-	    End Sub
-	    Private Sub Button2_Click(ByVal sender As Object, ByVal e As System.EventArgs)
-	        ClientScript.RegisterStartupScript(Page.GetType(), "closeWindow", "<script type='text/javascript'>RefreshParentPage()</script>")
-	    End Sub
+	```VB
+	Private Sub Button1_Click(ByVal sender As Object, ByVal e As System.EventArgs)
+	    ClientScript.RegisterStartupScript(Page.GetType(), "closeWindow", "<script type='text/javascript'>CloseOnReload()</script>")
+	End Sub
+	Private Sub Button2_Click(ByVal sender As Object, ByVal e As System.EventArgs)
+	    ClientScript.RegisterStartupScript(Page.GetType(), "closeWindow", "<script type='text/javascript'>RefreshParentPage()</script>")
+	End Sub
+	```
 
 
 >caution In general, outputting a JavaScript code from the code-behind is a general task that is not related to the RadWindow control - there are numerous resources on the Net that show how to do that. For example you can use the asp:scriptmanager's control RegisterStartupScript server method, or the ResponseScripts collection of RadAjaxManager. More information on the subject is also available in the following blog post: [Executing JavaScript function from server-side code](https://www.telerik.com/blogs/executing-javascript-function-from-server-side-code).

--- a/controls/window/how-to/show-radalert-that-blocks-the-entire-page.md
+++ b/controls/window/how-to/show-radalert-that-blocks-the-entire-page.md
@@ -38,15 +38,15 @@ In such a case, you need to:
 	
 	>caption Example 2: Open a RadWindow from the topmost page so it covers the entire browser viewport
 
-	**JavaScript**
-
-		var url = "some-page.aspx";
-		if (window.top != window && window.top.radopen) {
-			window.top.radopen(url);
-		}
-		else {
-			radopen(url);
-		}
+	```JavaScript
+	var url = "some-page.aspx";
+	if (window.top != window && window.top.radopen) {
+		window.top.radopen(url);
+	}
+	else {
+		radopen(url);
+	}
+	```
 
 
 	>tip You may want to store a reference to the current `window` context in a custom field in the newly created RadWindow so you can propagate its closing event from the main page, because it will no longer fire in the context of the current page.

--- a/controls/window/troubleshooting/common-issues.md
+++ b/controls/window/troubleshooting/common-issues.md
@@ -81,24 +81,24 @@ This happens because, by default, when a RadWindow is closed, its object is not 
 
 	* use the `setUrl()` client-side method to change the content page’s URL which will stop the media as well. e.g.
 
-		**JavaScript**
+		```JavaScript
+		function ShowWindow() {
+			var oWnd = window.radopen('Dialog1.aspx', 'window1'); //Opens the window  
+			oWnd.add_close(OnClientClose); //set a function to be called when RadWindow is closed  
+		}
 
-			function ShowWindow() {
-				var oWnd = window.radopen('Dialog1.aspx', 'window1'); //Opens the window  
-				oWnd.add_close(OnClientClose); //set a function to be called when RadWindow is closed  
-			}
-
-			function OnClientClose(oWnd) {
-				oWnd.setUrl("about:blank"); // Sets url to blank 
-				oWnd.remove_close(OnClientClose); //remove the close handler - it will be set again on the next opening 
-			}      
+		function OnClientClose(oWnd) {
+			oWnd.setUrl("about:blank"); // Sets url to blank 
+			oWnd.remove_close(OnClientClose); //remove the close handler - it will be set again on the next opening 
+		}      
+		```
 
 
-		**ASP.NET**
-
-			<telerik:RadWindowManager RenderMode="Lightweight" ID="RadWindowManager1" runat="server"> 
-			</telerik:RadWindowManager> 
-			<button onclick="ShowWindow(); return false;">open RadWindow</button> 
+		```ASP.NET
+		<telerik:RadWindowManager RenderMode="Lightweight" ID="RadWindowManager1" runat="server"> 
+		</telerik:RadWindowManager> 
+		<button onclick="ShowWindow(); return false;">open RadWindow</button> 
+		```
 
 
 
@@ -205,26 +205,26 @@ There are several workarounds you can consider implementing:
 * Make sure that the `<body>` or the `<form>` are the offset parents of the modal overlay. Further custom decoration should be applied to the form's content so that not affect RadWindow and its modality. 
 * Remove the scrollbars of the page when RadWindow opens and restore the when closed. Like in the example below: 
     
-    **JavaScript**
-
-        var bodyOverflow = "";   
-        var htmlOverflow = "";   
-        function openRadWindow()    
-        {   
-            //store the overflow   
-            bodyOverflow = document.body.style.overflow;   
-            htmlOverflow = document.documentElement.style.overflow;   
-            //hide the overflow   
-            document.body.style.overflow = "hidden";   
-            document.documentElement.style.overflow = "hidden";   
-            var oWnd = window.radopen(null, "RadWindow1");   
-            oWnd.add_close(closeHandler);   
-        }   
-               
-        function closeHandler(sender, args)   
-        {   
-            //restore the overflow   
-            document.body.style.overflow = bodyOverflow;   
-            document.documentElement.style.overflow = htmlOverflow;   
-            sender.remove_close(closeHandler);   
-        }
+	```JavaScript
+	var bodyOverflow = "";   
+	var htmlOverflow = "";   
+	function openRadWindow()    
+	{   
+		//store the overflow   
+		bodyOverflow = document.body.style.overflow;   
+		htmlOverflow = document.documentElement.style.overflow;   
+		//hide the overflow   
+		document.body.style.overflow = "hidden";   
+		document.documentElement.style.overflow = "hidden";   
+		var oWnd = window.radopen(null, "RadWindow1");   
+	 oWnd.add_close(closeHandler);   
+	}   
+	       
+	function closeHandler(sender, args)   
+	{   
+		//restore the overflow   
+		document.body.style.overflow = bodyOverflow;   
+		document.documentElement.style.overflow = htmlOverflow;   
+		sender.remove_close(closeHandler);   
+	} 
+	```

--- a/controls/window/troubleshooting/opening-from-the-server.md
+++ b/controls/window/troubleshooting/opening-from-the-server.md
@@ -21,30 +21,30 @@ There are several ways to work around this:
 
 * [Register a JavaScript function from the server-side]({%slug window/troubleshooting/executing-javascript-code-from-server%}) and do **not** use the **VisibleOnPageLoad** property, for example:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadWindow RenderMode="Lightweight" runat="server" ID="RadWindow1" NavigateUrl="https://google.com/"></telerik:RadWindow>
+	<asp:Button ID="Button4" Text="open the RadWindow from the server" runat="server" OnClick="Button1_Click" />
+	```
 
-		<telerik:RadWindow RenderMode="Lightweight" runat="server" ID="RadWindow1" NavigateUrl="https://google.com/"></telerik:RadWindow>
-		<asp:Button ID="Button4" Text="open the RadWindow from the server" runat="server" OnClick="Button1_Click" />
 
+	```C#
+	protected void Button1_Click(object sender, EventArgs e)
+	{
+		//business logic goes here
+	
+		string script = "function f(){$find(\"" + RadWindow1.ClientID + "\").show(); Sys.Application.remove_load(f);}Sys.Application.add_load(f);";
+		ScriptManager.RegisterStartupScript(Page, Page.GetType(), "key", script, true);
+	}
+	```
 
-	**C#**
-
-		protected void Button1_Click(object sender, EventArgs e)
-		{
-			//business logic goes here
-		
-			string script = "function f(){$find(\"" + RadWindow1.ClientID + "\").show(); Sys.Application.remove_load(f);}Sys.Application.add_load(f);";
-			ScriptManager.RegisterStartupScript(Page, Page.GetType(), "key", script, true);
-		}
-
-	**VB**
-
-		Protected Sub Button1_Click(sender As Object, e As System.EventArgs) Handles Button1.Click
-			'business logic goes here
-		
-			Dim script As String = "function f(){$find(""" + RadWindow1.ClientID + """).show(); Sys.Application.remove_load(f);}Sys.Application.add_load(f);"
-			ScriptManager.RegisterStartupScript(Page, Page.GetType(), "key", script, True)
-		End Sub
+	```VB
+	Protected Sub Button1_Click(sender As Object, e As System.EventArgs) Handles Button1.Click
+		'business logic goes here
+	
+		Dim script As String = "function f(){$find(""" + RadWindow1.ClientID + """).show(); Sys.Application.remove_load(f);}Sys.Application.add_load(f);"
+		ScriptManager.RegisterStartupScript(Page, Page.GetType(), "key", script, True)
+	End Sub
+	```
 
 
 * Reset the **VisibleOnPageLoad** property to **false** with code when suitable, depending on the particular scenario

--- a/controls/window/troubleshooting/wrong-radwindow-is-opened.md
+++ b/controls/window/troubleshooting/wrong-radwindow-is-opened.md
@@ -26,7 +26,7 @@ There are several approaches that can be taken to avoid this:
 
 It is sometimes rather difficult to track the markup of a complex site (e.g. a master page with content pages and user controls). In order to determine how many RadWindowManagers there are on the page the easiest way is to examine the rendered page in the browser (usually View Source after a right click) and look for the $create() statements at the end. Each of them corresponds to an AJAX-enabled control. Here follows a simple example. Note that it begins with the control type - Telerik.Web.UI.RadWindowManager. You can also see its server ID as the name property:
 
-**JavaScript**
+```JavaScript
 
 	Sys.Application.add_init(function() {
 
@@ -35,6 +35,7 @@ It is sometimes rather difficult to track the markup of a complex site (e.g. a m
 	{"clientStateFieldID":"RadWindowManager1_ClientState","formID":"form1","iconUrl":"","minimizeIconUrl":"","name":"RadWindowManager1","skin":"Default","windowControls":"[]"}, null, null, $get("RadWindowManager1"));
 
 	});
+```
 
 This can help locate the actual controls in the markup so you can make the necessary adjustments to the page.
 

--- a/controls/xmlhttppanel/getting-started/callback-configuration.md
+++ b/controls/xmlhttppanel/getting-started/callback-configuration.md
@@ -26,61 +26,61 @@ This article explains how to configure the RadXmlHttpPanel's callback:
 
 1. In the handler method, add the following code:
 
-	**C#**
-	
-		protected void RadXmlHttpPanel1_ServiceRequest(object sender, Telerik.Web.UI.RadXmlHttpPanelEventArgs e)
-		{
-			Label1.Text = "Label updated by XmlHttpPanel callback at: " + DateTime.Now.ToString();
-		}
+	```C#
+	protected void RadXmlHttpPanel1_ServiceRequest(object sender, Telerik.Web.UI.RadXmlHttpPanelEventArgs e)
+	{
+		Label1.Text = "Label updated by XmlHttpPanel callback at: " + DateTime.Now.ToString();
+	}
+	```
 
-	**VB**
-
-		Protected Sub RadXmlHttpPanel1_ServiceRequest(sender As Object, e As Telerik.Web.UI.RadXmlHttpPanelEventArgs)
-			Label1.Text = "Label updated by XmlHttpPanel callback at: " + Now.ToString()
-		End Sub
+	```VB
+	Protected Sub RadXmlHttpPanel1_ServiceRequest(sender As Object, e As Telerik.Web.UI.RadXmlHttpPanelEventArgs)
+		Label1.Text = "Label updated by XmlHttpPanel callback at: " + Now.ToString()
+	End Sub
+	```
 	
 
 
 
 1. Create an `<input/>` of type button that will call the **set_value** client method of the XmlHttpPanel, on a button click. You can also access the callback value from the client on the server using the `e.Value` property in the ServiceRequest event. Here is how the page and its code-behind should look after completing the steps above:
 
-	**ASP.NET**
+	```ASP.NET
+	<telerik:RadScriptManager ID="RadScriptManager1" runat="server">
+	</telerik:RadScriptManager>
+	<telerik:RadXmlHttpPanel runat="server" ID="RadXmlHttpPanel1" EnableClientScriptEvaluation="true"
+	    OnServiceRequest="RadXmlHttpPanel1_ServiceRequest">
+	    <asp:Label ID="Label2" runat="server"></asp:Label>
+	</telerik:RadXmlHttpPanel>
+	<br />
+	<br />
+	<br />
+	<input type="button" value="Set Value" onclick="SetValue();return false;" />
+	<script type="text/javascript">
+	    function SetValue()
+	    {
+	        var panel = $find("<%=RadXmlHttpPanel1.ClientID %>");
+	        panel.set_value("string_value");
+	    }
+	</script>
+	```
 
-	    <telerik:RadScriptManager ID="RadScriptManager1" runat="server">
-	    </telerik:RadScriptManager>
-	    <telerik:RadXmlHttpPanel runat="server" ID="RadXmlHttpPanel1" EnableClientScriptEvaluation="true"
-	        OnServiceRequest="RadXmlHttpPanel1_ServiceRequest">
-	        <asp:Label ID="Label2" runat="server"></asp:Label>
-	    </telerik:RadXmlHttpPanel>
-	    <br />
-	    <br />
-	    <br />
-	    <input type="button" value="Set Value" onclick="SetValue();return false;" />
-	    <script type="text/javascript">
-	        function SetValue()
-	        {
-	            var panel = $find("<%=RadXmlHttpPanel1.ClientID %>");
-	            panel.set_value("string_value");
-	        }
-	    </script>
 
+	```C#
+	protected void RadXmlHttpPanel1_ServiceRequest(object sender, Telerik.Web.UI.RadXmlHttpPanelEventArgs e)
+	{
+		Label1.Text = "Label updated by XmlHttpPanel callback at: " + DateTime.Now.ToString();
+		//access the callback value from the client on the server using the e.Value property
+		Label1.Text += "<br/> The returned value fron the client's set_value() function is: <strong>" + e.Value + "</strong>";
+	}
+	```
 
-	**C#**
-
-		protected void RadXmlHttpPanel1_ServiceRequest(object sender, Telerik.Web.UI.RadXmlHttpPanelEventArgs e)
-		{
-			Label1.Text = "Label updated by XmlHttpPanel callback at: " + DateTime.Now.ToString();
-			//access the callback value from the client on the server using the e.Value property
-			Label1.Text += "<br/> The returned value fron the client's set_value() function is: <strong>" + e.Value + "</strong>";
-		}
-
-	**VB**
-
-	    Protected Sub RadXmlHttpPanel1_ServiceRequest(ByVal sender As Object, ByVal e As Telerik.Web.UI.RadXmlHttpPanelEventArgs)
-	        Label1.Text = "Label updated by XmlHttpPanel callback at: " + DateTime.Now.ToString()
-	        'access the callback value from the client on the server using the e.Value property
-	        Label1.Text += "<br/> The returned value fron the client's set_value() function is: <strong>" + e.Value + "</strong>"
-	    End Sub
+	```VB
+	Protected Sub RadXmlHttpPanel1_ServiceRequest(ByVal sender As Object, ByVal e As Telerik.Web.UI.RadXmlHttpPanelEventArgs)
+	    Label1.Text = "Label updated by XmlHttpPanel callback at: " + DateTime.Now.ToString()
+	    'access the callback value from the client on the server using the e.Value property
+	    Label1.Text += "<br/> The returned value fron the client's set_value() function is: <strong>" + e.Value + "</strong>"
+	End Sub
+	```
 
 
 

--- a/controls/xmlhttppanel/getting-started/client-side-wcf-service-binding.md
+++ b/controls/xmlhttppanel/getting-started/client-side-wcf-service-binding.md
@@ -25,112 +25,111 @@ The following steps describe how to configure RadXmlHttpPanel so that it can use
 	* If WcfRequestMethod = "POST" the Value property should be set to "{"country": "value"}" or '{"country":"value"}'.
 	* If WcfRequestMethod = "GET" the Value property should be set to "country=value".
 
-		**ASP.NET**
-
-			<telerik:RadXmlHttpPanel runat="server" ID="XmlHttpPanelWCF"
-				Value="{&quot;country&quot;:&quot;Argentina&quot;}"
-				WcfServicePath="XmlHttpPanelWcfService.svc"
-				WcfServiceMethod="GetCustomersByCountry"
-				WcfRequestMethod="POST">
-			</telerik:RadXmlHttpPanel>
+		```ASP.NET
+		<telerik:RadXmlHttpPanel runat="server" ID="XmlHttpPanelWCF"
+			Value="{&quot;country&quot;:&quot;Argentina&quot;}"
+			WcfServicePath="XmlHttpPanelWcfService.svc"
+			WcfServiceMethod="GetCustomersByCountry"
+			WcfRequestMethod="POST">
+		</telerik:RadXmlHttpPanel>
+		```
 
 1. Define the Contracts of the WCF Service in an interface
 
-	**C#**
+	```C#
+	[ServiceContract]
+	public interface IXmlHttpPanelWcfService
+	{
+	    [OperationContract]
+	    [WebInvoke(Method = "POST", BodyStyle = WebMessageBodyStyle.Wrapped, ResponseFormat = WebMessageFormat.Json)]
+	    string GetCustomersByCountry(string country);
+	}
+	```
 	
-	    [ServiceContract]
-	    public interface IXmlHttpPanelWcfService
-	    {
-	        [OperationContract]
-	        [WebInvoke(Method = "POST", BodyStyle = WebMessageBodyStyle.Wrapped, ResponseFormat = WebMessageFormat.Json)]
-	        string GetCustomersByCountry(string country);
-	    }
-	
-	**VB**
-	
-	    <ServiceContract()> _
-	    Public Interface IXmlHttpPanelWcfService
-	        <OperationContract()> _
-	        <WebInvoke(Method:="POST", BodyStyle:=WebMessageBodyStyle.Wrapped, ResponseFormat:=WebMessageFormat.Json)> _
-	        Function GetCustomersByCountry(ByVal country As String) As String
-	    End Interface
+	```VB
+	<ServiceContract()> _
+	Public Interface IXmlHttpPanelWcfService
+	    <OperationContract()> _
+	    <WebInvoke(Method:="POST", BodyStyle:=WebMessageBodyStyle.Wrapped, ResponseFormat:=WebMessageFormat.Json)> _
+	    Function GetCustomersByCountry(ByVal country As String) As String
+	End Interface
+	```
 	
 1. Implement the contract in the WCF Service class:
 
-	**C#**
+	```C#
+	[AspNetCompatibilityRequirements(RequirementsMode = AspNetCompatibilityRequirementsMode.Allowed)]
+	public class XmlHttpPanelWcfService : IXmlHttpPanelWcfService
+	{
+	    public string GetCustomersByCountry(string country)
+	    {
+	        return "The content of XmlHttpPanel";
+	    }
+	}
+	```
 	
-		[AspNetCompatibilityRequirements(RequirementsMode = AspNetCompatibilityRequirementsMode.Allowed)]
-		public class XmlHttpPanelWcfService : IXmlHttpPanelWcfService
-		{
-		    public string GetCustomersByCountry(string country)
-		    {
-		        return "The content of XmlHttpPanel";
-		    }
-		}
-	
-	**VB**
-	
-		<AspNetCompatibilityRequirements(RequirementsMode:=AspNetCompatibilityRequirementsMode.Allowed)> _
-		Public Class XmlHttpPanelWcfService
-		    Implements IXmlHttpPanelWcfService
-		    Public Function GetCustomersByCountry(ByVal country As String) As String
-		        Return "The content of XmlHttpPanel"
-		    End Function
-		End Class
+	```VB
+	<AspNetCompatibilityRequirements(RequirementsMode:=AspNetCompatibilityRequirementsMode.Allowed)> _
+	Public Class XmlHttpPanelWcfService
+	    Implements IXmlHttpPanelWcfService
+	    Public Function GetCustomersByCountry(ByVal country As String) As String
+	        Return "The content of XmlHttpPanel"
+	    End Function
+	End Class
+	```
 	
 1. Define the configuration in web.config:
 
-	**XML**
-
-		<configuration>
-		    <system.serviceModel>
-		        <behaviors>
-		            <serviceBehaviors>
-		                <behavior name="XmlHttpPanelWcfBehavior">
-		                    <serviceMetadata httpGetEnabled="true" />
-		                    <serviceDebug includeExceptionDetailInFaults="true" />
-		                </behavior>
-		            </serviceBehaviors>
-		            <endpointBehaviors>
-		                <behavior name="XmlHttpPanelWcfBehavior">
-		                    <webHttp />
-		                </behavior>
-		            </endpointBehaviors>
-		        </behaviors>
-		        <services>
-		            <service behaviorConfiguration="XmlHttpPanelWcfBehavior" name="XmlHttpPanelWcfService">
-		                <endpoint address="" binding="webHttpBinding" contract="IXmlHttpPanelWcfService" behaviorConfiguration="XmlHttpPanelWcfBehavior"/>
-		            </service>
-		        </services>
-		    </system.serviceModel>
-		</configuration>
-		
+	```XML
+	<configuration>
+	    <system.serviceModel>
+	        <behaviors>
+	            <serviceBehaviors>
+	                <behavior name="XmlHttpPanelWcfBehavior">
+	                    <serviceMetadata httpGetEnabled="true" />
+	                    <serviceDebug includeExceptionDetailInFaults="true" />
+	                </behavior>
+	            </serviceBehaviors>
+	            <endpointBehaviors>
+	                <behavior name="XmlHttpPanelWcfBehavior">
+	                    <webHttp />
+	                </behavior>
+	            </endpointBehaviors>
+	        </behaviors>
+	        <services>
+	            <service behaviorConfiguration="XmlHttpPanelWcfBehavior" name="XmlHttpPanelWcfService">
+	                <endpoint address="" binding="webHttpBinding" contract="IXmlHttpPanelWcfService" behaviorConfiguration="XmlHttpPanelWcfBehavior"/>
+	            </service>
+	        </services>
+	    </system.serviceModel>
+	</configuration>
+	```
 1. Optionally, set the OnClientResponseEnding property to a client-side event handler that handles the response of the WCF Service.
 
-	**JavaScript**
-
-		function OnClientResponseEnding (sender, args)
-		{
-			//The actual result data is in the [WcfServiceMethod]Result property of the content object.
-			var data = args.get_content().GetCustomersByCountryResult,
-			args.set_cancel(true);
-		} 
+	```JavaScript
+	function OnClientResponseEnding (sender, args)
+	{
+		//The actual result data is in the [WcfServiceMethod]Result property of the content object.
+		var data = args.get_content().GetCustomersByCountryResult,
+		args.set_cancel(true);
+	} 
+	```
 			
 1. Optionally, set the OnClientResponseEnded and OnClientResponseError properties to client-side event handlers that respond when the WVF Service has successfully updated the panel’s content or when the WCF Service has generated an error while trying to service the item request, respectively.
 
-	**JavaScript**
+	```JavaScript
+	function OnClientResponseEnded (sender, args)
+	{
+		//...
+	}
 
-		function OnClientResponseEnded (sender, args)
-		{
-			//...
-		}
-
-		//Fired when the request for the items fails.
-		function OnClientResponseError (sender, args)
-		{
-			// Disable the notifing error alert.
-			args.set_cancelErrorAlert(true);
-			//...
-		}
+	//Fired when the request for the items fails.
+	function OnClientResponseError (sender, args)
+	{
+		// Disable the notifing error alert.
+		args.set_cancelErrorAlert(true);
+		//...
+	}
+	```
 
 

--- a/controls/xmlhttppanel/getting-started/webservice-configuration.md
+++ b/controls/xmlhttppanel/getting-started/webservice-configuration.md
@@ -24,20 +24,20 @@ This article explains how to configure a WebService to work with RadXmlHttpPanel
 
 1. Create a method that returns a string and accepts a single parameter of type object. Mark the method as [WebMethod] i.e.
 
-	**C#**
+	```C#
+	[WebMethod]
+	public string GetHTML(object context)
+	{
+		return "Content updated by XmlHttpPanel using WebService at: " + DateTime.Now.ToString();
+	}
+	```
 
-		[WebMethod]
-		public string GetHTML(object context)
-		{
-			return "Content updated by XmlHttpPanel using WebService at: " + DateTime.Now.ToString();
-		}
-
-	**VB**
-
-		<WebMethod> _
-		Public Function GetHTML(context As Object) As String
-			Return "Content updated by XmlHttpPanel using WebService at: " + DateTime.Now.ToString()
-		End Function
+	```VB
+	<WebMethod> _
+	Public Function GetHTML(context As Object) As String
+		Return "Content updated by XmlHttpPanel using WebService at: " + DateTime.Now.ToString()
+	End Function
+	```
 
 
 	The string returned from this method is the actual HTML content that will be pasted within the XmlHttpPanel.
@@ -46,102 +46,102 @@ This article explains how to configure a WebService to work with RadXmlHttpPanel
 
 1. Create an `<input/>` that will call the `set_value()` method of the XmlHttpPanel. Here is how the page with the XMLHttpPanel and the WebService code-behind file should look when accomplishing the steps above:
 
-	**ASP.NET**
-
-	    <asp:ScriptManager ID="ScriptManager1" runat="server">
-	    </asp:ScriptManager>
-	    <telerik:RadXmlHttpPanel runat="server" ID="RadXmlHttpPanel1" EnableClientScriptEvaluation="true"
-	        WebMethodPath="WebService.asmx" WebMethodName="GetHTML">
-	    </telerik:RadXmlHttpPanel>
-	    <br />
-	    <br />
-	    <br />
-	    <input type="button" value="Set Value" onclick="SetValue();return false;" />
-	    <script type="text/javascript">
-	        function SetValue()
-	        {
-	            var panel = $find("<%=RadXmlHttpPanel1.ClientID %>");
-	            var array = [];
-	            array[0] = "string0";
-	            array[1] = "string1";
-	            //you can pass any kind of object to the GetHTML method
-	            //right now we will pass an array
-	            panel.set_value(array);
-	        }
-	    </script>
-
-
+	```ASP.NET
+	<asp:ScriptManager ID="ScriptManager1" runat="server">
+	</asp:ScriptManager>
+	<telerik:RadXmlHttpPanel runat="server" ID="RadXmlHttpPanel1" EnableClientScriptEvaluation="true"
+	    WebMethodPath="WebService.asmx" WebMethodName="GetHTML">
+	</telerik:RadXmlHttpPanel>
+	<br />
+	<br />
+	<br />
+	<input type="button" value="Set Value" onclick="SetValue();return false;" />
+	<script type="text/javascript">
+	    function SetValue()
+	    {
+	        var panel = $find("<%=RadXmlHttpPanel1.ClientID %>");
+	        var array = [];
+	        array[0] = "string0";
+	        array[1] = "string1";
+	        //you can pass any kind of object to the GetHTML method
+	        //right now we will pass an array
+	        panel.set_value(array);
+	    }
+	</script>
+	```
 
 
-	**C#**
 
-		using System;
-		using System.Collections.Generic;
-		using System.Linq;
-		using System.Web;
-		using System.Web.Services;
-		
-		/// <summary>
-		/// Summary description for WebService
-		/// </summary>
-		[WebService(Namespace = "http://tempuri.org/")]
-		[WebServiceBinding(ConformsTo = WsiProfiles.BasicProfile1_1)]
-		// To allow this Web Service to be called from script, using ASP.NET AJAX, uncomment the following line.
-		[System.Web.Script.Services.ScriptService]
-		public class WebService : System.Web.Services.WebService
+
+	```C#
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Web;
+	using System.Web.Services;
+	
+	/// <summary>
+	/// Summary description for WebService
+	/// </summary>
+	[WebService(Namespace = "http://tempuri.org/")]
+	[WebServiceBinding(ConformsTo = WsiProfiles.BasicProfile1_1)]
+	// To allow this Web Service to be called from script, using ASP.NET AJAX, uncomment the following line.
+	[System.Web.Script.Services.ScriptService]
+	public class WebService : System.Web.Services.WebService
+	{
+		public WebService()
 		{
-			public WebService()
-			{
-				//Uncomment the following line if using designed components
-				//InitializeComponent();
-			}
-		
-			[WebMethod]
-			public string GetHTML(object context)
-			{
-				Dictionary<string, object> dictiionary = context as Dictionary<string, object>;
-		
-				//The value passed to the XmlHttpPanel can be of type object
-				object value = dictiionary["Value"];
-				string value1 = ((object[])(value))[0].ToString();
-				string value2 = ((object[])(value))[1].ToString();
-				return "Content updated by XmlHttpPanel using WebService at: "
-					+ DateTime.Now.ToString()
-					+ "<br/>These are the passed values to the XmlHttpPanel: <strong>" + value1 + " </strong> and  <strong>" + value2 + " </strong>";
-			}
+			//Uncomment the following line if using designed components
+			//InitializeComponent();
 		}
+	
+		[WebMethod]
+		public string GetHTML(object context)
+		{
+			Dictionary<string, object> dictiionary = context as Dictionary<string, object>;
+	
+			//The value passed to the XmlHttpPanel can be of type object
+			object value = dictiionary["Value"];
+			string value1 = ((object[])(value))[0].ToString();
+			string value2 = ((object[])(value))[1].ToString();
+			return "Content updated by XmlHttpPanel using WebService at: "
+				+ DateTime.Now.ToString()
+				+ "<br/>These are the passed values to the XmlHttpPanel: <strong>" + value1 + " </strong> and  <strong>" + value2 + " </strong>";
+		}
+	}
+	```
 
 
 
-	**VB**
-
-		Imports System.Collections.Generic
-		Imports System.Linq
-		Imports System.Web
-		Imports System.Web.Services
-		
-		''' <summary>
-		''' Summary description for WebService
-		''' </summary>
-		' To allow this Web Service to be called from script, using ASP.NET AJAX, uncomment the following line.
-		<WebService([Namespace] := "http://tempuri.org/")> _
-		<WebServiceBinding(ConformsTo := WsiProfiles.BasicProfile1_1)> _
-		<System.Web.Script.Services.ScriptService> _
-		Public Class WebService
-			Inherits System.Web.Services.WebService
-					'Uncomment the following line if using designed components
-					'InitializeComponent();
-			Public Sub New()
-			End Sub
-		
-			<WebMethod> _
-			Public Function GetHTML(context As Object) As String
-				Dim dictiionary As Dictionary(Of String, Object) = TryCast(context, Dictionary(Of String, Object))
-		
-				'The value passed to the XmlHttpPanel can be of type object
-				Dim value As Object = dictiionary("Value")
-				Dim value1 As String = DirectCast(value, Object())(0).ToString()
-				Dim value2 As String = DirectCast(value, Object())(1).ToString()
-				Return (Convert.ToString((Convert.ToString("Content updated by XmlHttpPanel using WebService at: " + DateTime.Now.ToString() + "<br/>These are the passed values to the XmlHttpPanel: <strong>") & value1) + " </strong> and  <strong>") & value2) + " </strong>"
-			End Function
-		End Class
+	```VB
+	Imports System.Collections.Generic
+	Imports System.Linq
+	Imports System.Web
+	Imports System.Web.Services
+	
+	''' <summary>
+	''' Summary description for WebService
+	''' </summary>
+	' To allow this Web Service to be called from script, using ASP.NET AJAX, uncomment the following line.
+	<WebService([Namespace] := "http://tempuri.org/")> _
+	<WebServiceBinding(ConformsTo := WsiProfiles.BasicProfile1_1)> _
+	<System.Web.Script.Services.ScriptService> _
+	Public Class WebService
+		Inherits System.Web.Services.WebService
+				'Uncomment the following line if using designed components
+				'InitializeComponent();
+		Public Sub New()
+		End Sub
+	
+		<WebMethod> _
+		Public Function GetHTML(context As Object) As String
+			Dim dictiionary As Dictionary(Of String, Object) = TryCast(context, Dictionary(Of String, Object))
+	
+			'The value passed to the XmlHttpPanel can be of type object
+			Dim value As Object = dictiionary("Value")
+			Dim value1 As String = DirectCast(value, Object())(0).ToString()
+			Dim value2 As String = DirectCast(value, Object())(1).ToString()
+			Return (Convert.ToString((Convert.ToString("Content updated by XmlHttpPanel using WebService at: " + DateTime.Now.ToString() + "<br/>These are the passed values to the XmlHttpPanel: <strong>") & value1) + " </strong> and  <strong>") & value2) + " </strong>"
+		End Function
+	End Class
+	```


### PR DESCRIPTION
Repairs code snippet formatting across 137 AJAX control documentation articles by wrapping raw ASP.NET, C#, JavaScript, and CSS examples in proper Markdown code fences.